### PR TITLE
🐳(project) use PostgreSQL instead of SQLite for development and tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,56 @@ jobs:
           name: Lint code with bandit
           command: ~/.local/bin/bandit -qr src/ashley sandbox
 
+  test-back:
+    docker:
+      - image: circleci/python:3.8-buster
+        environment:
+          DJANGO_SETTINGS_MODULE: settings
+          DJANGO_CONFIGURATION: Test
+          DJANGO_SECRET_KEY: ThisIsAnExampleKeyForTestPurposeOnly
+          PYTHONPATH: /home/circleci/fun/sandbox
+          DB_HOST: localhost
+          DB_NAME: ashley
+          DB_USER: fun
+          DB_PASSWORD: pass
+          DB_PORT: 5432
+      # services
+      - image: circleci/postgres:12-ram
+        environment:
+          POSTGRES_DB: test_ashley
+          POSTGRES_USER: fun
+          POSTGRES_PASSWORD: pass
+    working_directory: ~/fun
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-back-dependencies-{{ .Revision }}
+      # Attach the frontend production build
+      - attach_workspace:
+          at: ~/fun
+      # While running tests, we need to make the /data directory writable for
+      # the circleci user
+      - run:
+          name: Create writable /data
+          command: |
+            sudo mkdir /data && \
+            sudo chown circleci:circleci /data
+      # Run back-end (Django) test suite
+      #
+      # Nota bene: to run the django test suite, we need to ensure that
+      # Postgresql service is up and ready. To achieve this, we wrap the pytest
+      # command execution with dockerize, a tiny tool installed in the CircleCI
+      # image. In our case, dockerize will wait up to one minute that the database
+      # opened its tcp port (5432).
+      - run:
+          name: Run tests
+          command: |
+            dockerize \
+              -wait tcp://localhost:5432 \
+              -timeout 60s \
+                ~/.local/bin/pytest
+
   # ---- Packaging jobs ----
   package-back:
     docker:
@@ -297,11 +347,19 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-back:
+          requires:
+            - build-back
+          filters:
+            tags:
+              only: /.*/
 
       # Packaging: python
       #
       # Build the python package
       - package-back:
+          requires:
+            - test-back
           filters:
             tags:
               only: /.*/
@@ -314,6 +372,7 @@ workflows:
       - hub:
           requires:
             - build-docker
+            - test-back
           filters:
             branches:
               only: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,11 @@ RUN pip install -e .[dev]
 ARG DOCKER_USER
 USER ${DOCKER_USER}
 
+# Target database host (e.g. database engine following docker-compose services
+# name) & port
+ENV DB_HOST=postgresql \
+    DB_PORT=5432
+
 # Run django development server (wrapped by dockerize to ensure the db is ready
 # to accept connections before running the development server)
 CMD cd sandbox && \

--- a/bin/ashley
+++ b/bin/ashley
@@ -3,4 +3,6 @@
 declare DOCKER_USER
 DOCKER_USER="$(id -u):$(id -g)"
 
-DOCKER_USER=${DOCKER_USER} docker-compose run --service-ports ashley
+DOCKER_USER=${DOCKER_USER} docker-compose up -d postgresql
+DOCKER_USER=${DOCKER_USER} docker-compose run --rm dockerize dockerize -wait tcp://postgresql:5432 -timeout 60s
+DOCKER_USER=${DOCKER_USER} docker-compose run --rm --service-ports ashley

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 version: '3.4'
 
 services:
+  postgresql:
+    image: postgres:12
+    env_file:
+      - env.d/development/postgresql
+    ports:
+      - "15432:5432"
+
   ashley:
     build:
       context: .
@@ -13,7 +20,13 @@ services:
       PYLINTHOME: /app/.pylint.d
     env_file:
       - env.d/development/common
+      - env.d/development/postgresql
     ports:
       - "8090:8000"
     volumes:
       - .:/app
+    depends_on:
+      - "postgresql"
+
+  dockerize:
+    image: jwilder/dockerize

--- a/env.d/development/postgresql
+++ b/env.d/development/postgresql
@@ -1,0 +1,11 @@
+# Postgresql db container configuration
+POSTGRES_DB=ashley
+POSTGRES_USER=fun
+POSTGRES_PASSWORD=pass
+
+# App database configuration
+DB_HOST=postgresql
+DB_NAME=ashley
+DB_USER=fun
+DB_PASSWORD=pass
+DB_PORT=5432

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -130,13 +130,6 @@ class Development(Base):
     DEBUG = True
     ALLOWED_HOSTS = ["*"]
 
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
-        }
-    }
-
 
 class Test(Base):
     """Test environment settings"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ ci =
     twine==2.0.0
 sandbox =
     django-configurations==2.2
+    psycopg2-binary==2.8.4
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
## Purpose 

Use PostgreSQL instead of SQLite in Development environment.

## Proposal

- [x] Update docker-compose to start a postgresql container
- [x] Install dockerize
- [x] Update CircleCI configuration
- [x] Don't wait for postgresql container to run linters
