### PR TITLE
✨(project) add script to execute management commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
 # ---- Development image ----
 FROM core as development
 
+ENV PYTHONUNBUFFERED=1
+
 # Switch back to the root user to install development dependencies
 USER root:root
 
@@ -76,6 +78,8 @@ CMD cd sandbox && \
 
 # ---- Production image ----
 FROM core as production
+
+ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app/sandbox
 

--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+REPO_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd)"
+UNSET_USER=0
+COMPOSE_PROJECT="ashley"
+
+COMPOSE_FILE="${REPO_DIR}/docker-compose.yml"
+
+# _set_user: set (or unset) default user id used to run docker commands
+#
+# usage: _set_user
+#
+# You can override default user ID (the current host user ID), by defining the
+# USER_ID environment variable.
+#
+# To avoid running docker commands with a custom user, please set the
+# $UNSET_USER environment variable to 1.
+function _set_user() {
+
+    if [ $UNSET_USER -eq 1 ]; then
+        USER_ID=""
+        return
+    fi
+
+    # USER_ID = USER_ID or `id -u` if USER_ID is not set
+    USER_ID=${USER_ID:-$(id -u)}
+
+    echo "🙋(user) ID: ${USER_ID}"
+}
+
+# docker_compose: wrap docker-compose command
+#
+# usage: docker_compose [options] [ARGS...]
+#
+# options: docker-compose command options
+# ARGS   : docker-compose command arguments
+function _docker_compose() {
+
+    echo "🐳(compose) project: '${COMPOSE_PROJECT}' file: '${COMPOSE_FILE}'"
+    docker-compose \
+        -p "${COMPOSE_PROJECT}" \
+        -f "${COMPOSE_FILE}" \
+        --project-directory "${REPO_DIR}" \
+        "$@"
+}
+
+# _dc_run: wrap docker-compose run command
+#
+# usage: _dc_run [options] [ARGS...]
+#
+# options: docker-compose run command options
+# ARGS   : docker-compose run command arguments
+function _dc_run() {
+    _set_user
+
+    user_args="--user=$USER_ID"
+    if [ -z $USER_ID ]; then
+        user_args=""
+    fi
+
+    _docker_compose run --rm $user_args "$@"
+}
+
+# _dc_exec: wrap docker-compose exec command
+#
+# usage: _dc_exec [options] [ARGS...]
+#
+# options: docker-compose exec command options
+# ARGS   : docker-compose exec command arguments
+function _dc_exec() {
+    _set_user
+
+    echo "🐳(compose) exec command: '\$@'"
+
+    user_args="--user=$USER_ID"
+    if [ -z $USER_ID ]; then
+        user_args=""
+    fi
+
+    _docker_compose exec $user_args "$@"
+}
+
+# _django_manage: wrap django's manage.py command with docker-compose
+#
+# usage : _django_manage [ARGS...]
+#
+# ARGS : django's manage.py command arguments
+function _django_manage() {
+    _dc_run -w /app/sandbox "ashley" python manage.py "$@"
+}

--- a/bin/ashley
+++ b/bin/ashley
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-declare DOCKER_USER
-DOCKER_USER="$(id -u):$(id -g)"
+# shellcheck source=bin/_config.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
-DOCKER_USER=${DOCKER_USER} docker-compose up -d postgresql
-DOCKER_USER=${DOCKER_USER} docker-compose run --rm dockerize dockerize -wait tcp://postgresql:5432 -timeout 60s
-DOCKER_USER=${DOCKER_USER} docker-compose run --rm --service-ports ashley
+_docker_compose up -d postgresql
+_dc_run dockerize dockerize -wait tcp://postgresql:5432 -timeout 60s
+_dc_run --service-ports ashley

--- a/bin/manage
+++ b/bin/manage
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare DOCKER_USER
-DOCKER_USER="$(id -u):$(id -g)"
+# shellcheck source=bin/_config.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
-DOCKER_USER=${DOCKER_USER} docker-compose run --rm  -w /app/sandbox ashley python manage.py "$@"
+_django_manage "$@"

--- a/bin/manage
+++ b/bin/manage
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+declare DOCKER_USER
+DOCKER_USER="$(id -u):$(id -g)"
+
+DOCKER_USER=${DOCKER_USER} docker-compose run --rm  -w /app/sandbox ashley python manage.py "$@"

--- a/bin/pylint
+++ b/bin/pylint
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare DOCKER_USER
-DOCKER_USER="$(id -u):$(id -g)"
+# shellcheck source=bin/_config.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
-DOCKER_USER=${DOCKER_USER} docker-compose run --rm ashley pylint "$@"
+_dc_run ashley pylint "$@"

--- a/bin/pytest
+++ b/bin/pytest
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-declare DOCKER_USER
-DOCKER_USER="$(id -u):$(id -g)"
+# shellcheck source=bin/_config.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
-DOCKER_USER=${DOCKER_USER} docker-compose run \
-  -e DJANGO_CONFIGURATION=Test \
-  -e PYTHONPATH=/app/sandbox \
-  --rm ashley pytest "$@"
+_dc_run ashley pytest "$@"

--- a/bin/superuser
+++ b/bin/superuser
@@ -3,4 +3,4 @@
 # shellcheck source=bin/_config.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
-_docker_compose "$@"
+_django_manage createsuperuser "$@"

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -4,5 +4,5 @@ DJANGO_CONFIGURATION=Development
 DJANGO_SECRET_KEY=ThisIsAnExampleKeyForDevPurposeOnly
 
 # Python
-PYTHONUNBUFFERED=1
+PYTHONPATH=/app/sandbox
 


### PR DESCRIPTION
## Purpose

Execution of django management commands in development environment require to execute multiple commands. And, as developers, by definition, we are lazy.

## Proposal

Add a `bin/manage` script allows to execute directly django management commands inside a docker container.

Usage example : `bin/manage createsuperuser`