### PR TITLE
✨(project) add static type checking with mypy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,9 @@ jobs:
       - run:
           name: Lint code with bandit
           command: ~/.local/bin/bandit -qr src/ashley sandbox
+      - run:
+          name: Type-check code with mypy
+          command: ~/.local/bin/mypy src
 
   # ---- Packaging jobs ----
   package-back:

--- a/.dockerignore
+++ b/.dockerignore
@@ -25,3 +25,4 @@ docs
 .git
 .vscode
 db.sqlite3
+.mypy_cache

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ venv.bak/
 .pylint.d
 .pytest_cache
 db.sqlite3
+.mypy_cache

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ lint: \
   lint-isort \
   lint-black \
   lint-flake8 \
+  lint-mypy \
   lint-pylint \
   lint-bandit
 .PHONY: lint
@@ -52,6 +53,11 @@ lint-bandit: ## lint back-end python sources with bandit
 	@echo 'lint:bandit started…'
 	@$(COMPOSE_TEST_RUN_APP) bandit -qr src/ashley sandbox
 .PHONY: lint-bandit
+
+lint-mypy: ## type check back-end python sources with mypy
+	@echo 'lint:mypy started…'
+	@$(COMPOSE_TEST_RUN_APP_NODEPS) mypy src
+.PHONY: lint-mypy
 
 logs: ## display app logs (follow mode)
 	@$(COMPOSE) logs -f ashley

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ include_package_data = True
 install_requires =
     Django<3.0.0
     django-machina==1.0.2
+    oauthlib>=3.0.0
 package_dir =
     =src
 packages = find:
@@ -37,16 +38,19 @@ dev =
     ipdb==0.12.2
     ipython==7.9.0
     isort==4.3.21
+    mypy==0.761
     pyfakefs==3.7.1
     pylint==2.4.4
     pylint-django==2.0.13
     pytest==5.3.5
     pytest-cov==2.8.1
     pytest-django==3.8.0
+    factory_boy==2.12.0
 ci =
     twine==2.0.0
 sandbox =
     django-configurations==2.2
+    psycopg2-binary==2.8.4
 
 [options.packages.find]
 where = src
@@ -69,7 +73,7 @@ exclude =
     */migrations/*
 
 [isort]
-known_ashley=ashley
+known_ashley=ashley,fun_lti_provider,sandbox
 include_trailing_comma=True
 line_length=88
 multi_line_output=3
@@ -84,3 +88,9 @@ python_files =
 testpaths =
     tests
 
+[mypy]
+ignore_missing_imports = True
+
+[mypy-*.migrations.*]
+# Django migrations should not be type checked
+ignore_errors = True


### PR DESCRIPTION
## Purpose

Type hinting using the [PEP 484](https://www.python.org/dev/peps/pep-0484/) notation have been introduced in python 3.5. and I'm convinced that it's a good practice. 

Common bugs can be detected and avoided easily with static type checkers, and [mypy](http://mypy-lang.org/) is one of them.

## Proposal

- [x] Add `mypy` static  type checker in Makefile lint tasks 
- [x] update CircleCI configuration to run `mypy`
