### PR TITLE
🔧(sandbox) update security settings in sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - lti_provider django application
  - install `django-machina` forum in the `sandbox` project
 
+### Changed
+
+ - Update sandbox settings to be able to run Ashley in an `iframe` on multiple
+   external websites
+
 [unreleased]: https://github.com/openfun/ashley

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -54,6 +54,15 @@ class Base(Configuration):
     # In other cases, you should comment the following line to avoid security issues.
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+    # Disable Samesite flag in session and csrf cookies, because ashley is meant to
+    # run in an iframe on external websites.
+    # Note : The better solution is to send a flag Samesite=none, because
+    # modern browsers are considering Samesite=Lax by default when the flag is
+    # not specified.
+    # It will be possible to specify CSRF_COOKIE_SAMESITE="none" in Django 3.1
+    CSRF_COOKIE_SAMESITE = None
+    SESSION_COOKIE_SAMESITE = None
+
     # Application definition
     ROOT_URLCONF = "urls"
     WSGI_APPLICATION = "wsgi.application"
@@ -121,7 +130,6 @@ class Base(Configuration):
         "django.middleware.csrf.CsrfViewMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
-        "django.middleware.clickjacking.XFrameOptionsMiddleware",
         "machina.apps.forum_permission.middleware.ForumPermissionMiddleware",
     ]
 
@@ -216,15 +224,11 @@ class Production(Base):
     # https://docs.djangoproject.com/en/2.2/ref/checks/#security
     SILENCED_SYSTEM_CHECKS = values.ListValue(
         [
-            # Allow the X_FRAME_OPTIONS to be set to "SAMEORIGIN"
-            "security.W019"
+            # Allow to disable django.middleware.clickjacking.XFrameOptionsMiddleware
+            # It is necessary since ashley wil be displayed in an iframe on external LMS sites.
+            "security.W002"
         ]
     )
-    # The X_FRAME_OPTIONS value should be set to "SAMEORIGIN" to display
-    # DjangoCMS frontend admin frames. Dockerflow raises a system check security
-    # warning with this setting, one should add "security.W019" to the
-    # SILENCED_SYSTEM_CHECKS setting (see above).
-    X_FRAME_OPTIONS = "SAMEORIGIN"
 
     # For static files in production, we want to use a backend that includes a hash in
     # the filename, that is calculated from the file content, so that browsers always

--- a/src/lti_provider/views.py
+++ b/src/lti_provider/views.py
@@ -3,7 +3,6 @@
 from django import http
 from django.http import HttpRequest, HttpResponse
 from django.utils.module_loading import import_string
-from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 
 from lti_provider.exceptions import LTIException
@@ -13,7 +12,6 @@ from .settings import settings
 
 
 @csrf_exempt
-@xframe_options_exempt
 def launch(request: HttpRequest) -> HttpResponse:
     """Verify LTI launch request and call hook depending on the result."""
     lti = LTI(request)


### PR DESCRIPTION
## Purpose

Ashley is meant to run embedded in iframes on external websites.
With the current configuration, it is not possible because of the following reasons : 

 - django's [clickjacking middleware](https://docs.djangoproject.com/en/2.2/ref/clickjacking/) is sending a [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) header which prevent the `sandbox` project from running inside an iframe on an external website. None of the `X-Frame-Options` directive is suitable if we want to serve ashley as a service for multiple websites at the same time.

- Django CSRF and SESSION cookies are sent with the `SameSite=Lax` flag. If ashley is running inside an iframe on an external website, the cookies sent by ashley are ignored by the user browser.

## Proposal

### Concerning the clickjacking middleware

- Disable the clickjacking middleware

### Concerning the Samesite cookie flag : 

With django 2.2, we can only disable this flag by setting [SESSION_COOKIE_SAMESITE](https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SESSION_COOKIE_SAMESITE) and [CSRF_COOKIE_SAMESITE](https://docs.djangoproject.com/en/2.2/ref/settings/#csrf-cookie-samesite) to `None`.

The result is that the `Samesite` flag will not be sent with the `Set-Cookie` header. We will still have problem with modern browsers that tend to consider that cookies are "Samesite=Lax" by default (see [Chrome announcement](https://www.chromestatus.com/feature/5088147346030592)).

This issue will be [fixed](https://github.com/django/django/commit/b33bfc383935cd26e19a2cf71d066ac6edd1425f) in Django 3.1 and we will be able to send the flag `Samesite=None`.