### PR TITLE
✨(dev-tools) add a standalone LTI consumer to test ashley in development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,8 @@ jobs:
   lint-back:
     docker:
       - image: circleci/python:3.8-buster
+        environment:
+          PYTHONPATH: /home/circleci/fun/sandbox
     working_directory: ~/fun
     steps:
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - lti_provider django application
  - install `django-machina` forum in the `sandbox` project
  - custom user model, auth backend and LTI handlers in `ashley`
+ - standalone LTI consumer to test ashley in development
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ test: ## run back-end tests
 
 migrate:  ## run django migration for the ashley project.
 	@echo "$(BOLD)Running migrations$(RESET)"
+	@$(COMPOSE) up -d postgresql
 	@$(WAIT_DB)
 	@$(MANAGE) migrate
 .PHONY: migrate

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -8,3 +8,4 @@ PYTHONPATH=/app/sandbox
 
 # File cache for Machina attachments
 TMP_ATTACHMENT_DIR=/tmp
+PYTHONPATH=/app/sandbox

--- a/sandbox/dev_tools/__init__.py
+++ b/sandbox/dev_tools/__init__.py
@@ -1,0 +1,4 @@
+"""dev_tools is a django application providing tools for ashley developers."""
+
+# pylint: disable=invalid-name
+default_app_config = "dev_tools.apps.DevToolsAppConfig"

--- a/sandbox/dev_tools/apps.py
+++ b/sandbox/dev_tools/apps.py
@@ -1,0 +1,10 @@
+"""dev_tools application config."""
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class DevToolsAppConfig(AppConfig):
+    """Configuration class for the dev_tools app."""
+
+    verbose_name = _("Dev tools")
+    name = "dev_tools"

--- a/sandbox/dev_tools/forms.py
+++ b/sandbox/dev_tools/forms.py
@@ -1,0 +1,42 @@
+"""Forms definition for the dev_tools application."""
+
+from django import forms
+from django.utils.translation import gettext_lazy as _
+
+from lti_provider.models import LTIPassport
+
+
+class PassportChoiceField(forms.ModelChoiceField):
+    """Select a LTI password"""
+
+    def label_from_instance(self, obj):
+        return f"{obj.consumer.slug} - {obj.title}"
+
+
+class LTIConsumerForm(forms.Form):
+    """Form to configure the standalone LTI consumer."""
+
+    passport = PassportChoiceField(
+        queryset=LTIPassport.objects.all(), empty_label=None, label="Consumer"
+    )
+
+    user_id = forms.CharField(label="User ID", max_length=100, initial="jojo",)
+
+    course_id = forms.CharField(
+        label="Course ID",
+        max_length=100,
+        initial="course-v1:openfun+mathematics101+session01",
+    )
+    course_title = forms.CharField(
+        label="Course Title", max_length=100, initial="Mathematics 101"
+    )
+
+    role = forms.ChoiceField(
+        choices=(("Student", _("Student")), ("Instructor", _("Instructor")),)
+    )
+
+    presentation_locale = forms.ChoiceField(
+        choices=(("fr", "fr"), ("en", "en"), ("", "--none--")),
+        initial="fr",
+        required=False,
+    )

--- a/sandbox/dev_tools/templates/dev/consumer.html
+++ b/sandbox/dev_tools/templates/dev/consumer.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Simple LTI Launch Test</title>
+</head>
+
+<body style="margin:0px;padding:0px;overflow:hidden">
+
+<form action="{{ request.build_absolute_uri }}" method="post">
+    {% csrf_token %}
+    {{ form }}
+    <input type="submit" value="Display forum">
+</form>
+
+<hr />
+
+{% if lti_params %}
+    {% autoescape off %}
+        <form id="lti_form" action="{{ launch_url }}" method="post" target="lti_iframe">
+            {% for name,value in lti_params.items %}
+                <input type="hidden" name="{{ name }}" value="{{ value }}"/>
+            {% endfor %}
+        </form>
+    {% endautoescape %}
+
+    <iframe
+            class="controlled-iframe"
+            name="lti_iframe"
+            style="overflow:hidden;height:100vh;width:100vw"
+            srcdoc="<body>Loading...</body>"
+            frameborder="0"
+            allowfullscreen
+            allow="fullscreen *"
+            webkitallowfullscreen
+            mozallowfullscreen
+    >
+    </iframe>
+
+    <script>
+    var form = document.querySelector("#lti_form");
+    form.submit();
+    </script>
+{% endif %}
+
+</body>
+
+</html>

--- a/sandbox/dev_tools/urls.py
+++ b/sandbox/dev_tools/urls.py
@@ -1,0 +1,19 @@
+"""URLs for the dev_tools django application."""
+from django.conf.urls import url
+from django.urls import reverse_lazy
+from django.views.generic import RedirectView
+
+from . import views
+
+urlpatterns = [
+    url(
+        r"^$",
+        RedirectView.as_view(
+            url=reverse_lazy("dev_tools.views.consumer"), permanent=False
+        ),
+    ),
+    url(r"^consumer$", views.dev_consumer, name="dev_tools.views.consumer"),
+]
+
+#
+#

--- a/sandbox/dev_tools/views.py
+++ b/sandbox/dev_tools/views.py
@@ -1,0 +1,88 @@
+"""Views for the dev-tools application."""
+
+import uuid
+from urllib.parse import unquote
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.urls import reverse
+from django.views.decorators.csrf import csrf_exempt
+from oauthlib import oauth1
+
+from lti_provider.factories import LTIConsumerFactory, LTIPassportFactory
+from lti_provider.models import LTIPassport
+
+from .forms import LTIConsumerForm
+
+
+@csrf_exempt
+def dev_consumer(request: HttpRequest) -> HttpResponse:
+    """Display the standalone LTI consumer"""
+
+    # Ensure that at least the demo consumer exists with a passport
+    consumer = LTIConsumerFactory(slug="dev_consumer", title="Dev consumer")
+    passport = LTIPassportFactory(title="Dev passport", consumer=consumer)
+
+    if request.method == "POST":
+        form = LTIConsumerForm(request.POST)
+        if form.is_valid():
+            launch_url = request.build_absolute_uri(
+                reverse("lti_provider.views.launch")
+            )
+            lti_params = _generate_signed_parameters(form, launch_url, passport)
+            return render(
+                request,
+                "dev/consumer.html",
+                {"form": form, "lti_params": lti_params, "launch_url": launch_url},
+            )
+    else:
+        form = LTIConsumerForm()
+
+    return render(request, "dev/consumer.html", {"form": form})
+
+
+def _generate_signed_parameters(form: LTIConsumerForm, url: str, passport: LTIPassport):
+
+    user_id = form.cleaned_data["user_id"]
+
+    lti_parameters = {
+        "lti_message_type": "basic-lti-launch-request",
+        "lti_version": "LTI-1p0",
+        "resource_link_id": str(uuid.uuid4()),
+        "lis_person_contact_email_primary": f"{user_id}@example.com",
+        "lis_person_sourcedid": user_id,
+        "user_id": str(uuid.uuid5(uuid.NAMESPACE_DNS, form.cleaned_data["user_id"])),
+        "context_id": form.cleaned_data["course_id"],
+        "context_title": form.cleaned_data["course_title"],
+        "roles": form.cleaned_data["role"],
+    }
+    if form.cleaned_data["presentation_locale"]:
+        lti_parameters["launch_presentation_locale"] = form.cleaned_data[
+            "presentation_locale"
+        ]
+
+    oauth_client = oauth1.Client(
+        client_key=passport.oauth_consumer_key, client_secret=passport.shared_secret
+    )
+    # Compute Authorization header which looks like:
+    # Authorization: OAuth oauth_nonce="80966668944732164491378916897",
+    # oauth_timestamp="1378916897", oauth_version="1.0", oauth_signature_method="HMAC-SHA1",
+    # oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"
+    _uri, headers, _body = oauth_client.sign(
+        url,
+        http_method="POST",
+        body=lti_parameters,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    # Parse headers to pass to template as part of context:
+    oauth_dict = dict(
+        param.strip().replace('"', "").split("=")
+        for param in headers["Authorization"].split(",")
+    )
+
+    signature = oauth_dict["oauth_signature"]
+    oauth_dict["oauth_signature"] = unquote(signature)
+    oauth_dict["oauth_nonce"] = oauth_dict.pop("OAuth oauth_nonce")
+    lti_parameters.update(oauth_dict)
+    return lti_parameters

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -229,6 +229,8 @@ class Development(Base):
         },
     }
 
+    INSTALLED_APPS = Base.INSTALLED_APPS + ["dev_tools"]
+
 
 class Test(Base):
     """Test environment settings"""

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -1,14 +1,21 @@
 """
 ashley URLs
 """
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 from machina import urls as machina_urls
 
 from lti_provider import urls as lti_urls
 
+from dev_tools import urls as dev_urls
+from dev_tools.apps import DevToolsAppConfig
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("forum/", include(machina_urls)),
     path("lti/", include(lti_urls)),
 ]
+
+if DevToolsAppConfig.name in settings.INSTALLED_APPS:
+    urlpatterns += [path("dev/", include(dev_urls))]

--- a/src/lti_provider/factories.py
+++ b/src/lti_provider/factories.py
@@ -1,5 +1,5 @@
 """Factories for the ``lti_provider``."""
-
+import factory
 from factory.django import DjangoModelFactory
 
 from . import models
@@ -12,9 +12,20 @@ class LTIConsumerFactory(DjangoModelFactory):
         model = models.LTIConsumer
         django_get_or_create = ("slug",)
 
+    slug = factory.Sequence(lambda n: f"consumer{n}")
+    title = factory.Sequence(lambda n: f"Consumer {n}")
+
 
 class LTIPassportFactory(DjangoModelFactory):
     """Factory to create LTI passport."""
 
     class Meta:
         model = models.LTIPassport
+        django_get_or_create = (
+            "title",
+            "consumer",
+        )
+
+    title = factory.Sequence(lambda n: f"passport {n}")
+
+    consumer = factory.SubFactory(LTIConsumerFactory)


### PR DESCRIPTION
## Purpose

Developers should have a simple way to test ashley without having to run an openedx instance.

## Proposal

Add a standalone LTI consumer to test ashley.


## How to test it ?

- `make bootstrap`
- `make run`
- go to http://localhost:8090/dev/consumer

For the moment it only displays a greeting message if you are authenticated.
But when `feature/ashley-auth-backend` and `feature/permission-management` will be merged, you'll be able to see the forum in action.