### PR TITLE
⬆️(dependencies) upgrade django-machina to support django 3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,10 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-    Django<3.0.0
-    django-machina==1.0.2
+    Django>=3.0.0
+    django-machina==1.1
     oauthlib>=3.0.0
+    django-haystack==3.0b1
 package_dir =
     =src
 packages = find:


### PR DESCRIPTION
## Purpose

A new [release](https://django-machina.readthedocs.io/en/stable/release_notes/v1.1.html) of django-machina is out, with django 3 support :tada: 

As mentionned in [this issue](https://github.com/ellmetha/django-machina/issues/189#issuecomment-598808312) it only works with django-haystack 3.0b1 which is a pre-release version.

## Proposal

- [x] Update dependencies
