### PR TITLE
✨(ashley) add extra permission to course administrators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - `asley.machina_extensions.forum` application to extend django-machina's
    forum model.
  - automatic forum creation based on the context of the LTI launch request
+ - Instructor and Administrator LTI roles have special permissions on their
+   forum.
 
 ### Changed
 

--- a/src/ashley/permissions/__init__.py
+++ b/src/ashley/permissions/__init__.py
@@ -10,6 +10,18 @@ DEFAULT_GROUP_FORUM_PERMISSIONS = [
     "can_edit_own_posts",
     "can_post_without_approval",
     "can_vote_in_polls",
-    "can_attach_file",
-    "can_download_file",
 ]
+
+DEFAULT_ADMIN_GROUP_FORUM_PERMISSIONS = DEFAULT_GROUP_FORUM_PERMISSIONS + [
+    "can_post_announcements",
+    "can_post_stickies",
+    "can_delete_own_posts",
+    "can_create_polls",
+    "can_lock_topics",
+    "can_edit_posts",
+    "can_delete_posts",
+    "can_approve_posts",
+    "can_reply_to_locked_topics",
+]
+
+DEFAULT_INSTRUCTOR_GROUP_FORUM_PERMISSIONS = DEFAULT_ADMIN_GROUP_FORUM_PERMISSIONS

--- a/src/lti_provider/lti.py
+++ b/src/lti_provider/lti.py
@@ -156,13 +156,3 @@ class LTI:
 
         """
         return re.search(r"^course-v[0-9]:.*$", self.get_param("context_id"))
-
-    @property
-    def launch_presentation_locale(self):
-        """LTI launch_presentation_locale.
-
-        Returns:
-            str: the locale present in launch_presentation_locale or fallback to en
-
-        """
-        return self.get_param("launch_presentation_locale", "en")

--- a/tests/lti_provider/test_lti.py
+++ b/tests/lti_provider/test_lti.py
@@ -224,18 +224,3 @@ class LTITestCase(TestCase):
         lti_parameters.update({"context_title": "the context title"})
         lti = self._verified_lti_request(lti_parameters)
         self.assertEqual("the context title", lti.context_title)
-
-    def test_launch_presentation_locale(self):
-        """Test the retrieval of the launch_presentation_locale"""
-        lti_parameters = {
-            "lti_message_type": "basic-lti-launch-request",
-            "lti_version": "LTI-1p0",
-            "resource_link_id": "df7",
-        }
-        lti = self._verified_lti_request(lti_parameters)
-        # If launch_presentation_locale parameter is not defined, it defaults to en
-        self.assertEqual("en", lti.launch_presentation_locale)
-
-        lti_parameters.update({"launch_presentation_locale": "fr"})
-        lti = self._verified_lti_request(lti_parameters)
-        self.assertEqual("fr", lti.launch_presentation_locale)


### PR DESCRIPTION
## Purpose

Users having roles Administrator or Instructor should have extra permissions to moderate their forum.

## Proposal

- [x] Detect admin roles based on group names and grant them a specific set of permissions on group creation