### PR TITLE
🐛(project) fix production docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ WORKDIR /builder
 # Copy required python dependencies
 COPY setup.py setup.cfg MANIFEST.in /builder/
 COPY ./src/ashley /builder/src/ashley/
+COPY ./src/lti_provider /builder/src/lti_provider/
 
 RUN mkdir /install && \
     pip install --prefix=/install .[sandbox]


### PR DESCRIPTION
## Purpose

The lti_provider module is missing in the production docker image.

## Proposal

- [x] Fix the Dockerfile
