### PR TITLE
🐛(sandbox) move factory_boy from dev to sandbox dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,18 +41,18 @@ dev =
     isort==4.3.21
     mypy==0.761
     pyfakefs==3.7.1
-    pylint==2.4.4
     pylint-django==2.0.13
-    pytest==5.3.5
+    pylint==2.4.4
     pytest-cov==2.8.1
     pytest-django==3.8.0
-    factory_boy==2.12.0
+    pytest==5.3.5
 ci =
     twine==2.0.0
 sandbox =
     django-configurations==2.2
-    psycopg2-binary==2.8.4
     dockerflow==2019.10.0
+    factory_boy==2.12.0
+    psycopg2-binary==2.8.4
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
## Purpose

The factory-boy module is listed in the dev dependencies, but the sandbox needs it.

## Proposal

- [x] Fix dependencies in `setup.cfg`