### PR TITLE
🐛(sandbox) add missing dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ sandbox =
     dockerflow==2019.10.0
     factory_boy==2.12.0
     psycopg2-binary==2.8.4
+    gunicorn==20.0.4
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
## Purpose

The gunicorn dependency is missing in the sandbox.

## Proposal

- [x] Add gunicorn dependency for the sandbox in `setup.cfg`