### PR TITLE
🔧(sandbox) update settings to fix or silent security warnings

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -68,6 +68,9 @@ class Base(Configuration):
     CSRF_COOKIE_SAMESITE = None
     SESSION_COOKIE_SAMESITE = None
 
+    # Privacy
+    SECURE_REFERRER_POLICY = "same-origin"
+
     # Application definition
     ROOT_URLCONF = "urls"
     WSGI_APPLICATION = "wsgi.application"
@@ -276,7 +279,11 @@ class Production(Base):
         [
             # Allow to disable django.middleware.clickjacking.XFrameOptionsMiddleware
             # It is necessary since ashley wil be displayed in an iframe on external LMS sites.
-            "security.W002"
+            "security.W002",
+            # SECURE_SSL_REDIRECT is not defined in the base configuration
+            "security.W008",
+            # No value is defined for SECURE_HSTS_SECONDS
+            "security.W004",
         ]
     )
 


### PR DESCRIPTION
## Purpose

A system check of the sandbox project is listing the following issues :

```
WARNINGS:
?: (security.W004) You have not set a value for the SECURE_HSTS_SECONDS setting. If your entire site is served only over SSL, you may want to consider setting a value and enabling HTTP Strict Transport Security. Be sure to read the documentation first; enabling HSTS carelessly can cause serious, irreversible problems.
?: (security.W008) Your SECURE_SSL_REDIRECT setting is not set to True. Unless your site should be available over both SSL and non-SSL connections, you may want to either set this setting True or configure a load balancer or reverse-proxy server to redirect all connections to HTTPS.
?: (security.W022) You have not set the SECURE_REFERRER_POLICY setting. Without this, your site will not send a Referrer-Policy header. You should consider enabling this header to protect user privacy.
```

## Proposal
Update sandbox settings to fix security.W022 and to silent security.W008 and security.W004