### PR TITLE
🔊(logging) update loggers to follow module name convention

### DIFF
--- a/src/ashley/auth/backend.py
+++ b/src/ashley/auth/backend.py
@@ -8,7 +8,7 @@ from django.core.exceptions import PermissionDenied
 from lti_provider.default.backend import LTIBackend as BaseLTIBackend
 from lti_provider.lti import LTI
 
-logger = logging.getLogger("ashley")
+logger = logging.getLogger(__name__)
 
 
 class LTIBackend(BaseLTIBackend):

--- a/src/ashley/models.py
+++ b/src/ashley/models.py
@@ -11,7 +11,7 @@ from machina.core.db.models import model_factory
 
 from lti_provider.models import LTIConsumer
 
-logger = logging.getLogger("ashley")
+logger = logging.getLogger(__name__)
 
 
 class AbstractUser(DjangoAbstractUser):

--- a/src/ashley/views.py
+++ b/src/ashley/views.py
@@ -18,7 +18,7 @@ from .defaults import DEFAULT_FORUM_BASE_PERMISSIONS, DEFAULT_FORUM_ROLES_PERMIS
 Forum = get_model("forum", "Forum")  # pylint: disable=C0103
 LTIContext = get_model("ashley", "LTIContext")  # pylint: disable=C0103
 
-logger = logging.getLogger("ashley")
+logger = logging.getLogger(__name__)
 
 
 class ForumLTIView(BaseLTIView):

--- a/src/lti_provider/default/backend.py
+++ b/src/lti_provider/default/backend.py
@@ -9,7 +9,7 @@ from django.core.exceptions import PermissionDenied
 
 from ..lti import LTI
 
-logger = logging.getLogger("lti_provider")
+logger = logging.getLogger(__name__)
 
 USER_MODEL = get_user_model()
 

--- a/src/lti_provider/validator.py
+++ b/src/lti_provider/validator.py
@@ -39,7 +39,7 @@ from oauthlib.oauth1 import RequestValidator
 
 from .models import LTIPassport
 
-logger = logging.getLogger("lti_provider")
+logger = logging.getLogger(__name__)
 
 
 class LTIRequestValidator(RequestValidator):


### PR DESCRIPTION
## Purpose

The logger names used in `ashley` and `lti_provider` are too generic.

## Proposal

Instead of using "ashley" and "lti_provider" as logger name, we now use full module name to be more precise.