### PR TITLE
✨(ashley) render emojis with emojione

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## Added
+
+ - render emoji with emojione on forum posts
+
 ## [1.0.0-beta.0] - 2020-04-16
 
 ### Added

--- a/src/frontend/js/ashley.ts
+++ b/src/frontend/js/ashley.ts
@@ -1,7 +1,12 @@
 import * as AshleyEditor from './components/AshleyEditor';
+import { renderEmojis } from './utils/emojis';
 
 // expose some modules to the global window object
 declare var window: any;
 window.Ashley = {
   Editor: AshleyEditor,
 };
+
+document.addEventListener('DOMContentLoaded', event => {
+  renderEmojis();
+});

--- a/src/frontend/js/utils/emojis.ts
+++ b/src/frontend/js/utils/emojis.ts
@@ -1,0 +1,13 @@
+import * as emojione from 'emojione';
+
+export const renderEmojis = () => {
+  // @ts-ignore
+  emojione.imagePathPNG = '//cdn.jsdelivr.net/emojione/assets/svg/';
+  // @ts-ignore
+  emojione.fileExtension = '.svg';
+  document.querySelectorAll('span.emoji').forEach(emojiElement => {
+    if (emojiElement.textContent) {
+      emojiElement.innerHTML = emojione.toImage(emojiElement.textContent);
+    }
+  });
+};

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -46,12 +46,14 @@
     "webpack-cli": "3.3.11"
   },
   "dependencies": {
+    "@types/emojione": "^2.2.6",
     "draft-js": "0.11.5",
     "draft-js-anchor-plugin": "2.0.3",
     "draft-js-buttons": "2.0.2",
     "draft-js-emoji-plugin": "2.1.3",
     "draft-js-plugins-editor": "3.0.0",
     "draft-js-static-toolbar-plugin": "3.0.1",
+    "emojione": "4.5.0",
     "es6-shim": "0.35.5",
     "react": "16.13.1",
     "react-dom": "16.13.1"

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -4,6 +4,8 @@
 @import 'draft-js-static-toolbar-plugin/lib/plugin';
 @import 'draft-js-anchor-plugin/lib/plugin';
 
+@import './objects/_emojis';
+
 .card.forumlist .card-header .forum-count-col,
 .card.forumlist .card-header .forum-last-post-col,
 .card.topiclist .card-header .topic-count-col,

--- a/src/frontend/scss/objects/_emojis.scss
+++ b/src/frontend/scss/objects/_emojis.scss
@@ -1,0 +1,14 @@
+img.emojione {
+  width: 1.5em;
+  height: 1.5em;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  img.emojione {
+    width: 1em;
+    height: 1em;
+  }
+}

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -4,9 +4,6 @@ module.exports = {
   // webpack config for production.
   mode: 'development',
 
-  // Currently, @babel/preset-env is unaware that using import() with Webpack relies on Promise internally.
-  // Environments which do not have builtin support for Promise, like Internet Explorer, will require both
-  // the promise and iterator polyfills be added manually.
   entry: ['./js/ashley.ts'],
 
   // chunkFilename must have a unique and different name on each build

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1097,6 +1097,11 @@
     "@types/react" "*"
     immutable "~3.7.4"
 
+"@types/emojione@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@types/emojione/-/emojione-2.2.6.tgz#467767e7c844738c60c0c1c2ce30af1d3236bc69"
+  integrity sha512-2OJGfbqLOFFawMp61cxpJ+QsLA/2LDUdqWb2YMVNP8q/FXSxdkv0hdqm3EcjNfyfcpZ0HjOjMATwXdx/xpTlOA==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -2831,6 +2836,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emojione@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/emojione/-/emojione-4.5.0.tgz#cf1f5d417394988296aef72bd3ac3d480890838a"
+  integrity sha512-Tq55Y3UgPOnayFDN+Qd6QMP0rpoH10a1nhSFN27s8gXW3qymgFIHiXys2ECYYAI134BafmI3qP9ni2rZOe9BjA==
 
 emojione@^2.2.7:
   version "2.2.7"


### PR DESCRIPTION
## Purpose

Emojis are rendered with emojione in ashley WISYWIG editor. But when a
forum post is displayed, emojis are rendered with the native font of
the user's browser. In consequence, the rendering is inconsistent and
sometime emojis are not displayed at all.

## Proposal

Use emojione to render emojis everywhere.