### PR TITLE
🐛(sandbox) add middleware to force SameSite=None on Django cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
  - render emoji with emojione on forum posts
  - add support for Moodle in ashley's LTI authentication backend
+ - add SameSiteNoneMiddleware to force SameSite=None on CSRF and session cookies
 
 ## [1.0.0-beta.0] - 2020-04-16
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -135,6 +135,7 @@ class Base(Configuration):
     ]
 
     MIDDLEWARE = [
+        "ashley.middleware.SameSiteNoneMiddleware",
         "django.middleware.security.SecurityMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.middleware.locale.LocaleMiddleware",

--- a/src/ashley/middleware.py
+++ b/src/ashley/middleware.py
@@ -1,0 +1,28 @@
+"""Declare the middlewares related to Ashley ."""
+
+from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
+
+
+class SameSiteNoneMiddleware(MiddlewareMixin):
+    """
+    This middleware forces the attribute SameSite="None" for CSRF and SESSION
+    cookies.
+
+    Django < 3.1 does not allow to set the SameSite="None" for the
+    session and CSRF cookies. As a result, it causes issues with modern
+    browsers that consider SameSite="Lax" by default.
+
+    This middleware is a temporary fix until this feature is available
+    in a stable version of Django.
+    """
+
+    @staticmethod
+    def process_response(request, response):
+        """Force the samesite=None on session and CSRF cookies if defined."""
+
+        if settings.SESSION_COOKIE_NAME in response.cookies:
+            response.cookies[settings.SESSION_COOKIE_NAME]["samesite"] = "None"
+        if settings.CSRF_COOKIE_NAME in response.cookies:
+            response.cookies[settings.CSRF_COOKIE_NAME]["samesite"] = "None"
+        return response

--- a/tests/ashley/test_middleware.py
+++ b/tests/ashley/test_middleware.py
@@ -1,0 +1,47 @@
+"""Test suite for Ashley's middlewares"""
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.test import RequestFactory, TestCase
+
+from ashley.middleware import SameSiteNoneMiddleware
+
+
+class SameSiteNoneMiddlewareTestCase(TestCase):
+    """Test the SameSiteNoneMiddleware middleware"""
+
+    def setUp(self):
+        """Override the setUp method to instanciate and serve a request factory."""
+        super().setUp()
+        self.request_factory = RequestFactory()
+
+    def test_samesite_override(self):
+        """Test that the samesite attribute is rewritten for session and CSRF cookies"""
+
+        def get_response(request: HttpRequest) -> HttpResponse:
+            test_response = HttpResponse("OK")
+            # Set a session cookie with samesite=lax
+            test_response.set_cookie(
+                settings.SESSION_COOKIE_NAME, value="session_cookie", samesite="lax"
+            )
+            # Set a CSRF cookie with no samesite attribute
+            test_response.set_cookie(settings.CSRF_COOKIE_NAME, value="csrf_cookie")
+            # Set another custom cookie with samesite=strict attribute
+            test_response.set_cookie(
+                "another_cookie", value="some_value", samesite="strict"
+            )
+            return test_response
+
+        middleware = SameSiteNoneMiddleware(get_response)
+        response = middleware(self.request_factory.get("/"))
+
+        # The middleware should have transformed samesite=lax into samesite=None
+        # for the session cookie
+        self.assertEqual(
+            "None", response.cookies[settings.SESSION_COOKIE_NAME]["samesite"]
+        )
+        # The middleware should have added a samesite=None attribute to the CSRF cookie
+        self.assertEqual(
+            "None", response.cookies[settings.CSRF_COOKIE_NAME]["samesite"]
+        )
+        # The middleware should not have changed the samesite attribute for the custom cookie
+        self.assertEqual("strict", response.cookies["another_cookie"]["samesite"])


### PR DESCRIPTION
## Purpose

Django < 3.1 does not allow to set the SameSite="None" attribute for the session and CSRF cookies. As a result, it causes issues with modern browsers that consider SameSite="Lax" by default. 

## Proposal

- [x] Add a middleware to fix this before the public release of Django 3.1.
- [x] Test it.
