### PR TITLE
♻️(front) transform ashleyeditor component in functional component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
  - update draftjs link decorator to open links in new tab and to add attribute
    `rel="nofollow noopener noreferrer"`
+ - refactor `<AshleyEditor />` in functional component using hooks
 
 ### Fixed
 

--- a/src/frontend/js/ashley.ts
+++ b/src/frontend/js/ashley.ts
@@ -1,10 +1,12 @@
-import * as AshleyEditor from './components/AshleyEditor';
+import { init } from './components/AshleyEditor';
 import { renderEmojis } from './utils/emojis';
 
 // expose some modules to the global window object
 declare var window: any;
 window.Ashley = {
-  Editor: AshleyEditor,
+  Editor: {
+    init,
+  },
 };
 
 document.addEventListener('DOMContentLoaded', event => {

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -18,6 +18,11 @@
   border-radius: 0.25rem;
   padding: 1em;
   min-height: 10em;
+  position: relative;
+}
+
+.ashley-editor-toolbar {
+  position: relative;
 }
 
 .ashley-editor-buttons button {


### PR DESCRIPTION
## Purpose

We want to rewrite the ashleyeditor component in functional way using
hooks. To keep toolbar in top of the editor we use a css hack forcing
the top position on top on the editor.

## Proposal

- [x] refactor `<AshleyEditor />` in functional component using hooks