### PR TITLE
💄(ashley) fix heading button rendering in ashley editor on firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - add support for Moodle in ashley's LTI authentication backend
  - add SameSiteNoneMiddleware to force SameSite=None on CSRF and session cookies
 
+### Fixed
+
+  - heading buttons rendering in ashley editor on Firefox
+
 ## [1.0.0-beta.0] - 2020-04-16
 
 ### Added

--- a/src/frontend/js/components/AshleyEditor/index.tsx
+++ b/src/frontend/js/components/AshleyEditor/index.tsx
@@ -98,7 +98,10 @@ export class AshleyEditor extends React.Component<MyEditorProps, any> {
       <div>
         <Toolbar>
           {(externalProps: any) => (
-            <div ref={toolbar => (this.toolbarRef = toolbar)}>
+            <div
+              ref={toolbar => (this.toolbarRef = toolbar)}
+              className="ashley-editor-buttons"
+            >
               <BoldButton {...externalProps} />
               <ItalicButton {...externalProps} />
               <UnderlineButton {...externalProps} />

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -19,3 +19,7 @@
   padding: 1em;
   min-height: 10em;
 }
+
+.ashley-editor-buttons button {
+  width: 40px;
+}


### PR DESCRIPTION
## Purpose

On firefox, the heading buttons (H1/H2/H3) are displayed on two lines.
