### PR TITLE
✨(ashley) update draftjs link decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## Added
+### Added
 
  - render emoji with emojione on forum posts
  - add support for Moodle in ashley's LTI authentication backend
  - add SameSiteNoneMiddleware to force SameSite=None on CSRF and session cookies
+ 
+### Changed
+
+ - update draftjs link decorator to open links in new tab and to add attribute
+   `rel="nofollow noopener noreferrer"`
 
 ## [1.0.0-beta.0] - 2020-04-16
 

--- a/src/ashley/editor/decorators.py
+++ b/src/ashley/editor/decorators.py
@@ -15,7 +15,11 @@ def link(props):
     """
     title = props.get("title")
     href = props.get("url", "#")
-    anchor_properties = {"href": href}
+    anchor_properties = {
+        "href": href,
+        "target": "_blank",
+        "rel": "nofollow noopener noreferrer",
+    }
 
     if title is not None:
         anchor_properties["title"] = title


### PR DESCRIPTION
## Purpose

Links posted in forum conversation are opened in the iframe displaying the forum. It's confusing for the forum users.

Also, if posted links are non secure (`http://`), a security error blocks the request when a user clicks on it :

> Mixed Content: The page at 'https://lti-consumer/' was loaded over HTTPS, but requested an insecure resource 'http://forum-post-link.example.com/'. This request has been blocked; the content must be served over HTTPS.

## Proposal

- [ ] Add `target="_blank"` attribute to links to open them in a new tab
- [ ] Add `rel="noopener"` and `rel="noreferrer"` attribute to avoid [tabnagging](https://mathiasbynens.github.io/rel-noopener/)
- [ ] Add `rel="nofollow"` attribute to prevent SEO abusing (even if forums are private in the current state of ashley, it will prevent future problems if we change that in a future release)
