### PR TITLE
🚸(front) improve focus management on ashleyeditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - update draftjs link decorator to open links in new tab and to add attribute
    `rel="nofollow noopener noreferrer"`
  - refactor `<AshleyEditor />` in functional component using hooks
+ - improve focus management on `<AshleyEditor />`
 
 ### Fixed
 

--- a/src/frontend/js/components/AshleyEditor/index.tsx
+++ b/src/frontend/js/components/AshleyEditor/index.tsx
@@ -51,8 +51,8 @@ const AshleyEditor = (props: MyEditorProps) => {
   });
 
   useEffect(() => {
-    if (props.autofocus && editorRef.current) {
-      editorRef.current.focus();
+    if (props.autofocus) {
+      focusEditor();
     }
   }, []);
 
@@ -61,6 +61,12 @@ const AshleyEditor = (props: MyEditorProps) => {
       convertToRaw(stateEditor.getCurrentContent()),
     );
     setEditorState(stateEditor);
+  };
+
+  const focusEditor = () => {
+    if (editorRef.current != null) {
+      editorRef.current.focus();
+    }
   };
 
   const keyBinding = (command: string, stateEditor: EditorState) => {
@@ -77,6 +83,7 @@ const AshleyEditor = (props: MyEditorProps) => {
       <div
         className="ashley-editor-widget"
         ref={editorContainerRef}
+        onClick={focusEditor}
         style={
           toolbarRef.current
             ? {

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -19,6 +19,7 @@
   padding: 1em;
   min-height: 10em;
   position: relative;
+  cursor: text;
 }
 
 .ashley-editor-toolbar {


### PR DESCRIPTION
## Purpose

To toggle focus on `AshleyEditor` component, a user can only click on the placeholder text.

## Proposal

Improve this behavior by extending the clickable area to the whole editor.

