### PR TITLE
🔖(ashley) bump version to 1.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0-beta.1] - 2020-05-04
+
 ### Added
 
  - render emoji with emojione on forum posts
@@ -50,5 +52,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - Update sandbox settings to be able to run Ashley in an `iframe` on multiple
    external websites
 
-[Unreleased]: https://github.com/openfun/ashley/compare/v1.0.0-beta.0...master
+[Unreleased]: https://github.com/openfun/ashley/compare/v1.0.0-beta.1...master
+[1.0.0-beta.1]: https://github.com/openfun/ashley/compare/v1.0.0-beta.0...v1.0.0-beta.1
 [1.0.0-beta.0]: https://github.com/openfun/ashley/compare/d767ba96aedcbc7d48fba5fefad2b93b9d623cc8...v1.0.0-beta.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ashley
-version = 1.0.0-beta.0
+version = 1.0.0-beta.1
 description = A self-hosted discussion forum for learning
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ashley",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "A self-hosted alternative discussion forum for OpenEdx",
   "scripts": {
     "build": "tsc --noEmit && webpack",


### PR DESCRIPTION
### Added

 - render emoji with emojione on forum posts
 - add support for Moodle in ashley's LTI authentication backend
 - add SameSiteNoneMiddleware to force SameSite=None on CSRF and session cookies

### Changed

 - update draftjs link decorator to open links in new tab and to add attribute
   `rel="nofollow noopener noreferrer"`
 - refactor `<AshleyEditor />` in functional component using hooks
 - improve focus management on `<AshleyEditor />`

### Fixed

  - heading buttons rendering in ashley editor on Firefox