### PR TITLE
💄(template) use a fluid container for a better iframe integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - build the forum CSS theme inside ashley instead of using the compiled CSS
    file distributed with django-machina
  - coalesce SASS color variables between django-machina and bootstrap
+ - use a fluid container for a better iframe integration
 
 ## [1.0.0-beta.1] - 2020-05-04
 

--- a/src/ashley/templates/board_base.html
+++ b/src/ashley/templates/board_base.html
@@ -9,7 +9,7 @@
 {% block body %}
 {% block header %}
 {% endblock header %}
-<div class="my-5 container" id="main_container">
+<div class="my-0 px-2 container-fluid" id="main_container">
   <div class="row">
     <div class="col-12">
       {% block breadcrumb %}{% include "partials/breadcrumb.html" %}{% endblock breadcrumb %}


### PR DESCRIPTION
## Purpose

When integrated in a small iframe, Ashley's layout is not using the full width available.

## Proposal

- [x] Use the bootstrap fluid container, that use the entire width of the viewport.


## Relevant documentation for this review

- [Bootstrap layout](https://getbootstrap.com/docs/4.0/layout/overview/)
- [Bootstrap spacing](https://getbootstrap.com/docs/4.0/utilities/spacing/)