### PR TITLE
🐛(project) fix Makefile to build frontend assets in bootstrap target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ bootstrap: ## Prepare Docker images for the project
 bootstrap: \
   env.d/development/crowdin \
 	build \
+	build-front \
 	migrate
 .PHONY: bootstrap
 


### PR DESCRIPTION
## Purpose

On the first bootstrap of the project with `make boostrap && make
run`, assets are missing and we need to run `make build-front`
manually.

## Proposal

- [x] Fix `bootstrap` target in the Makefile

