### PR TITLE
🐛(back) fix signature max length errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - upgrade django-haystack to 3.0b2
  - upgrade django from 3.0 to 3.1
 
+### Fixed
+
+ - fix signature max length errors caused by the draft.js markup
+
 ## Removed
 
  - remove `SameSiteNoneMiddleware`

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -205,10 +205,13 @@ class Base(Configuration):
     }
 
     # Machina
-    MACHINA_MARKUP_WIDGET = "ashley.editor.widgets.DraftEditor"
     MACHINA_MARKUP_LANGUAGE = ("ashley.editor.draftjs_renderer", {})
-    MACHINA_USER_DISPLAY_NAME_METHOD = "get_public_username"
+    MACHINA_MARKUP_MAX_LENGTH_VALIDATOR = (
+        "ashley.validators.MarkupNullableMaxLengthValidator"
+    )
+    MACHINA_MARKUP_WIDGET = "ashley.editor.widgets.DraftEditor"
     MACHINA_PROFILE_AVATARS_ENABLED = False
+    MACHINA_USER_DISPLAY_NAME_METHOD = "get_public_username"
 
 
 class Development(Base):

--- a/src/ashley/validators.py
+++ b/src/ashley/validators.py
@@ -1,0 +1,41 @@
+"""Validators for the ashley application."""
+
+from html.parser import HTMLParser
+
+from django.core import validators
+from machina.models.fields import render_func
+
+
+class MarkupNullableMaxLengthValidator(validators.MaxLengthValidator):
+    """
+    Ensure that the length of the plain text contained in a markup is lower than
+    or equal the specified max length. Also, it provides a way to not validate
+    an input if the max length is None.
+    """
+
+    def __call__(self, value):
+        if self.limit_value is None:
+            # If the limit value is None, this means that there is no
+            # limit value at all. The default validation process is not
+            # performed.
+            return
+        # Render the value to HTML using MACHINA_MARKUP_LANGUAGE
+        html_value = render_func(value)
+        # Extract plain text from html
+        html_parser = HTMLFilter()
+        html_parser.feed(html_value)
+        # Validate the extracted text length
+        super().__call__(html_parser.text)
+
+
+class HTMLFilter(HTMLParser):
+    """HTML parser to extract plain text from a HTML fragment."""
+
+    text = ""
+
+    def error(self, message):
+        """Ignore errors"""
+
+    def handle_data(self, data):
+        """Concatenate the plain text found in each element."""
+        self.text += data

--- a/tests/ashley/test_validators.py
+++ b/tests/ashley/test_validators.py
@@ -1,0 +1,32 @@
+"""Test suite for ashley validators"""
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from ashley.validators import MarkupNullableMaxLengthValidator
+
+
+class TestMarkupNullableMaxLengthValidator(TestCase):
+    """Test the MarkupNullableMaxLengthValidator validator class"""
+
+    # pylint: disable=no-self-use
+    def test_none_limit(self):
+        """The validator should not raise any exception if the defined limit is None."""
+        validator = MarkupNullableMaxLengthValidator(None)
+        validator("")
+
+    def test_limit_ok(self):
+        """The validator should not raise any exception if the text contained in the
+        Draft.js markup is lower than or equal to the defined limit."""
+
+        # This the representation of "**Test** :boom:" (test in bold and boom emoji)
+        # in DraftJS markup.
+        draftjs_markup = (
+            '{"blocks":[{"key":"4h6tb","text":"Test 💥","type":"unstyled","depth":0,'
+            '"inlineStyleRanges":[{"offset":0,"length":5,"style":"BOLD"}],"entityRanges":'
+            '[{"offset":5,"length":1,"key":0}],"data":{}}],"entityMap":{"0":{"type":"emoji",'
+            '"mutability":"IMMUTABLE","data":{"emojiUnicode":"💥"}}}}'
+        )
+        MarkupNullableMaxLengthValidator(255)(draftjs_markup)
+        MarkupNullableMaxLengthValidator(6)(draftjs_markup)
+        with self.assertRaises(ValidationError):
+            MarkupNullableMaxLengthValidator(5)(draftjs_markup)


### PR DESCRIPTION
## Purpose

When a user try to set a signature containing rich text, a max length
validation error is raised. (See #85 )

This is due to the fact that the entire draft.js markup length is checked, not only the plain text.


## Proposal

- [x] Add a custom validator
- [x] Set [MACHINA_MARKUP_MAX_LENGTH_VALIDATOR](https://django-machina.readthedocs.io/en/stable/release_notes/v1.1.1.html) in sandbox settings


Fixes #85.