### PR TITLE
🐛(front) fix Draft.js editor resize issue with static toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
  - fix signature max length errors caused by the draft.js markup
+ - fix Draft.js editor resize issue with static toolbar
 
 ## Removed
 

--- a/src/frontend/js/components/AshleyEditor/index.tsx
+++ b/src/frontend/js/components/AshleyEditor/index.tsx
@@ -36,8 +36,6 @@ const AshleyEditor = (props: MyEditorProps) => {
     return EditorState.createEmpty();
   });
 
-  const toolbarRef = useRef(null as HTMLDivElement | null);
-  const editorContainerRef = useRef(null as HTMLDivElement | null);
   const editorRef = useRef(null as PluginEditor | null);
 
   // Instantiate plugins in a state to avoid instantiation on every render
@@ -86,19 +84,8 @@ const AshleyEditor = (props: MyEditorProps) => {
   };
 
   return (
-    <div>
-      <div
-        className="ashley-editor-widget"
-        ref={editorContainerRef}
-        onClick={focusEditor}
-        style={
-          toolbarRef.current
-            ? {
-                top: `${toolbarRef.current.offsetHeight}px`,
-              }
-            : {}
-        }
-      >
+    <div className="ashley-editor-wrapper">
+      <div className="ashley-editor-widget" onClick={focusEditor}>
         <Editor
           ref={editorRef}
           editorState={editorState}
@@ -109,17 +96,7 @@ const AshleyEditor = (props: MyEditorProps) => {
         />
         <emojiPlugin.EmojiSuggestions />
       </div>
-      <div
-        className="ashley-editor-toolbar"
-        ref={toolbarRef}
-        style={
-          editorContainerRef.current
-            ? {
-                top: `-${editorContainerRef.current.offsetHeight}px`,
-              }
-            : {}
-        }
-      >
+      <div className="ashley-editor-toolbar">
         <toolbarPlugin.Toolbar>
           {(externalProps: any) => (
             <div className="ashley-editor-buttons">

--- a/src/frontend/scss/objects/_editor.scss
+++ b/src/frontend/scss/objects/_editor.scss
@@ -1,3 +1,9 @@
+.ashley-editor-wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column-reverse;
+}
+
 .ashley-editor-widget {
   border: 1px solid $gray-400;
   border-radius: 0.25rem;
@@ -8,7 +14,10 @@
 }
 
 .ashley-editor-toolbar {
-  position: relative;
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: 2;
 }
 
 .ashley-editor-buttons button {


### PR DESCRIPTION
## Purpose

We used a CSS hack to be able to place the Draft.js static toolbar
plugin above the editor, because it was not possible to place directly
the static-toolbar component above the editor.

This hack does not handle well the resizing of the editor, because of
the way it computes the height of the editor. It is one time behind
the reality.

Here is the result, as explained in #110 : 
![](https://user-images.githubusercontent.com/2926/100752958-7ba8f900-33e9-11eb-998c-4d3e5974104d.gif)

## Proposal

Use absolute positionning for the toolbar instead of relative.
It avoids computing the height of the editor to position it.
