### PR TITLE
🐛(package) add missing `upgrades` directory in distributed artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- `upgrades` directory is missing from the published docker image
+
 ## [1.0.0-beta.3] - 2020-12-03
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ COPY --from=back-builder /install /usr/local
 
 # Copy runtime-required files
 COPY ./sandbox /app/sandbox
+COPY ./upgrades /app/upgrades
 COPY ./docker/files/usr/local/bin/entrypoint /usr/local/bin/entrypoint
 
 # Gunicorn


### PR DESCRIPTION
## Purpose

The `upgrades` directory is missing from the production docker image
published on Docker Hub. As a consequence, it is not possible to run
the upgrade scripts when using it.

## Proposal

- [x] Include the `upgrades` directory in the production docker image

