### PR TITLE
📌(pyup) add pyup filter to elasticsearch dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     django-lti-toolbox==1.0.0b1
     django-machina==1.1.3
     draftjs_exporter==4.1.1
-    elasticsearch>=5.0.0,<6.0.0
+    elasticsearch>=5.0.0,<6.0.0 # pyup: >=5.0.0,<6.0.0
     oauthlib>=3.0.0
 package_dir =
     =src


### PR DESCRIPTION
## Purpose

We don't want to upgrade the `elasticsearch` python package to a version
greater than 5, because Haystack doesn't support it.

## Proposal

- [x] Add a pyup filter in the requirements for the `elasticsearch` package