### PR TITLE
🔖(ashley) bump version to 1.0.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0-beta.4] - 2020-12-22
+
 ### Added
 
 - enable sentry_sdk in the sandbox
@@ -108,7 +110,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - Update sandbox settings to be able to run Ashley in an `iframe` on multiple
    external websites
 
-[Unreleased]: https://github.com/openfun/ashley/compare/v1.0.0-beta.3...master
+[Unreleased]: https://github.com/openfun/ashley/compare/v1.0.0-beta.4...master
+[1.0.0-beta.4]: https://github.com/openfun/ashley/compare/v1.0.0-beta.3...v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/openfun/ashley/compare/v1.0.0-beta.2...v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/openfun/ashley/compare/v1.0.0-beta.1...v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/openfun/ashley/compare/v1.0.0-beta.0...v1.0.0-beta.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ashley
-version = 1.0.0-beta.3
+version = 1.0.0-beta.4
 description = A self-hosted discussion forum for learning
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ashley",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "A self-hosted discussion forum for learning",
   "scripts": {
     "build": "tsc --noEmit && webpack",


### PR DESCRIPTION
### Added

- enable sentry_sdk in the sandbox
- allow users with empty username to define it

### Changed

- email and public_username are now optional for LTI authentication
- detect and generate unique user id for OpenedX studio users

### Fixed

- `upgrades` directory is missing from the published docker image
