### PR TITLE
🐛(search) fix serialization error in search index update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - upgrade django-machina from 1.1.3 to 1.1.4
  - add button to insert quotes in the draftjs editor
 
+### Fixed
+
+ - fix serialization error in search index update
+
 ## [1.0.0-beta.4] - 2020-12-22
 
 ### Added

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -253,7 +253,7 @@ class Base(Configuration):
     )
     MACHINA_MARKUP_WIDGET = "ashley.editor.widgets.DraftEditor"
     MACHINA_PROFILE_AVATARS_ENABLED = False
-    MACHINA_USER_DISPLAY_NAME_METHOD = "get_public_username"
+    MACHINA_USER_DISPLAY_NAME_METHOD = "get_public_username_with_default"
 
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")

--- a/src/ashley/defaults.py
+++ b/src/ashley/defaults.py
@@ -65,3 +65,8 @@ DRAFTJS_EXPORTER_CONFIG = lazy(
     },
     dict,
 )()
+
+
+INDEXABLE_USER_DISPLAY_NAME_METHOD = getattr(
+    settings, "ASHLEY_INDEXABLE_USER_DISPLAY_NAME_METHOD", "get_public_username"
+)

--- a/src/ashley/models.py
+++ b/src/ashley/models.py
@@ -48,6 +48,10 @@ class AbstractUser(DjangoAbstractUser):
 
     def get_public_username(self):
         """Getter for the public username of the user."""
+        return self.public_username
+
+    def get_public_username_with_default(self):
+        """Getter for the public username of the user."""
         return self.public_username or _("Anonymous")
 
     class Meta:

--- a/src/ashley/templates/forum_search/search.html
+++ b/src/ashley/templates/forum_search/search.html
@@ -1,0 +1,120 @@
+{% extends 'board_base.html' %}
+{% load i18n %}
+{% load highlight %}
+
+{% block sub_title %}{% trans "Search" %}{% endblock sub_title %}
+
+{% block content %}
+{% if not query %}
+<div class="row">
+  <div class="col-12">
+    <h1>{% trans "Search" %}</h1>
+  </div>
+</div>
+<div class="row">
+  <div class="col-12">
+    <div class="card post-edit">
+      <div class="card-header">
+        <h3 class="m-0 card-title h5">{% trans "Search forums" %}</h3>
+      </div>
+      <div class="card-body">
+        <form method="get" action="." class="form">
+          {% include "partials/form_field.html" with field=form.q %}
+          <div class="checkbox">
+            <label for="{{ form.search_topics.auto_id }}">
+              {{ form.search_topics }}
+              {{ form.search_topics.label }}
+            </label>
+          </div>
+          {% include "partials/form_field.html" with field=form.search_poster_name %}
+          {% include "partials/form_field.html" with field=form.search_forums %}
+          <div class="form-actions">
+            <input type="submit" class="btn btn-large btn-primary" value="{% trans "Search" %}" />
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% else %}
+<div class="row">
+  <div class="col-12">
+    <h1>{% trans "Search" %}
+    &nbsp;
+    <a href="{% url 'forum_search:search' %}" class="btn btn-sm btn-primary"><i class="fas fa-search"></i>&nbsp;{% trans "New search" %}</a></h1>
+  </div>
+</div>
+<div class="mb-3 row">
+  <div class="col-6 col-md-4 forum-actions-block">
+    <p class="mt-1 mb-0 text-muted">
+      {% blocktrans trimmed count number_of_results=page.paginator.count %}
+      Your search has returned <b>{{ number_of_results }}</b> result
+      {% plural %}
+      Your search has returned <b>{{ number_of_results }}</b> results
+      {% endblocktrans %}
+    </p>
+  </div>
+  <div class="col-12 col-md-8 pagination-block">
+    {% if page.has_previous or page.has_next %}
+    {% with pagination_size="pagination-sm justify-content-end" %}
+    {% include "forum_search/pagination.html" %}
+    {% endwith %}
+    {% endif %}
+  </div>
+</div>
+<div class="row">
+  <div class="col-12">
+    <div class="card resultslist">
+      <div class="card-header">
+        <h3 class="m-0 card-title h5">
+          <i class="fas fa-search"></i>&nbsp;{% trans "Results" %}
+        </h3>
+      </div>
+      <div class="p-0 card-body">
+        <table class="table">
+          {% for result in page.object_list %}
+          <tr>
+            <td class="post-name">
+              <a href="{% url 'forum_conversation:topic' result.forum_slug result.forum result.topic_slug result.topic %}" class="topic-name-link">{{ result.topic_subject }}</a>
+              <div>
+                <div class="post-created">
+                  {% if result.poster %}
+                  {% url 'forum_member:profile' result.poster as poster_url %}
+                  {% blocktrans trimmed with poster_url=poster_url username=result.poster_name|default:_("Anonymous") creation_date=result.created %}
+                  By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
+                  {% endblocktrans %}
+                  {% else %}
+                  {% blocktrans trimmed with poster_username=result.poster_name|default:_("Anonymous") creation_date=result.created %}
+                  By: {{ poster_username }} on {{ creation_date }}
+                  {% endblocktrans %}
+                  {% endif %}
+                </div>
+              </div>
+            </td>
+            <td class="post-content">
+              {% highlight result.text with request.GET.q max_lenght 800 %}
+            </td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td>
+              {% trans "No results." %}
+            </td>
+          </tr>
+          {% endfor %}
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% if page.has_previous or page.has_next %}
+<div class="mt-3 row">
+  <div class="col-md-12 pagination-block">
+    {% with pagination_size="pagination-sm justify-content-end" %}
+      {% include "forum_search/pagination.html" %}
+    {% endwith %}
+  </div>
+</div>
+{% endif %}
+{% endif %}
+{% endblock content %}


### PR DESCRIPTION
## Purpose

The haystack command `update_index` crashes while indexing posts with
a serialization error. It happens when a message is posted by a user
having an empty public_username field.

This is due to the fact that in this specific case, we are returning a
default public_username ("Anonymous") translated with gettext_lazy.
And lazy proxy values are not directly serializable into JSON.


## Proposal

- [x] do not index the default «Anonymous» username
- [x] update the search result template to display the default username if not specified in the search result

