### PR TITLE
✨(front) add button to insert quotes to the draftjs editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
  - upgrade django-machina from 1.1.3 to 1.1.4
+ - add button to insert quotes in the draftjs editor
 
 ## [1.0.0-beta.4] - 2020-12-22
 

--- a/src/frontend/js/components/AshleyEditor/index.tsx
+++ b/src/frontend/js/components/AshleyEditor/index.tsx
@@ -9,6 +9,7 @@ import {
   OrderedListButton,
   UnderlineButton,
   UnorderedListButton,
+  BlockquoteButton,
 } from 'draft-js-buttons';
 import createEmojiPlugin, { EmojiPluginConfig } from 'draft-js-emoji-plugin';
 import Editor from 'draft-js-plugins-editor';
@@ -108,6 +109,7 @@ const AshleyEditor = (props: MyEditorProps) => {
               <HeadlineOneButton {...externalProps} />
               <HeadlineTwoButton {...externalProps} />
               <HeadlineThreeButton {...externalProps} />
+              <BlockquoteButton {...externalProps} />
               <UnorderedListButton {...externalProps} />
               <OrderedListButton {...externalProps} />
               <emojiPlugin.EmojiSelect {...externalProps} />

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 
 @import './_variables';
+@import './_mixin';
 
 @import 'bootstrap/scss/bootstrap';
 

--- a/src/frontend/scss/_mixin.scss
+++ b/src/frontend/scss/_mixin.scss
@@ -1,0 +1,6 @@
+@mixin blockquote {
+  background: $gray-100;
+  border-left: 10px solid $gray-400;
+  color: $gray-600;
+  padding: 0.5em 10px;
+}

--- a/src/frontend/scss/objects/_conversation_topic_detail.scss
+++ b/src/frontend/scss/objects/_conversation_topic_detail.scss
@@ -38,6 +38,10 @@
         }
       }
 
+      blockquote {
+        @include blockquote;
+      }
+
       .post-signature {
         margin-top: 20px;
         margin-bottom: 20px;

--- a/src/frontend/scss/objects/_editor.scss
+++ b/src/frontend/scss/objects/_editor.scss
@@ -11,6 +11,10 @@
   min-height: 10em;
   position: relative;
   cursor: text;
+
+  blockquote {
+    @include blockquote;
+  }
 }
 
 .ashley-editor-toolbar {


### PR DESCRIPTION

## Purpose
The input field to add a message is based on the draftjs editor and draftjs plugins. We want to be able to add a quote via this editor.

Based on issue https://github.com/openfun/ashley/issues/67


## Proposal

Add a "quote" button to the editor's toolbar that allows formatting part of a message as a quote
![Capture d’écran 2021-01-07 à 16 48 18](https://user-images.githubusercontent.com/76939263/103912975-4a1dfe80-5108-11eb-9023-bf9ece57e9ca.png)
![teest](https://user-images.githubusercontent.com/76939263/103913130-83566e80-5108-11eb-881f-c34128e1878d.png)

