### PR TITLE
✨(front) add code blocks to the draftjs editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - upgrade django-machina from 1.1.3 to 1.1.4
  - add button to insert quotes in the draftjs editor
  - limit forum listing to the current user LTIContext id
+ - add code blocks in the editor and auto-highlight code in the forum
 
 ### Fixed
 

--- a/src/frontend/js/ashley.ts
+++ b/src/frontend/js/ashley.ts
@@ -1,5 +1,6 @@
 import { init } from './components/AshleyEditor';
 import { renderEmojis } from './utils/emojis';
+import { renderHighlight } from './utils/highlight';
 
 // expose some modules to the global window object
 declare var window: any;
@@ -11,4 +12,5 @@ window.Ashley = {
 
 document.addEventListener('DOMContentLoaded', (event) => {
   renderEmojis();
+  renderHighlight();
 });

--- a/src/frontend/js/components/AshleyEditor/index.spec.tsx
+++ b/src/frontend/js/components/AshleyEditor/index.spec.tsx
@@ -1,7 +1,14 @@
-import { render, screen } from '@testing-library/react';
+import { createEvent } from '@testing-library/dom';
+import { render, fireEvent, screen } from '@testing-library/react';
 import React from 'react';
-
 import { AshleyEditor } from '.';
+import { BlockMapFactory } from '../../utils/test/factories';
+/***
+ *  useful ressources
+    Draft.js's components does not change its content with keypress, keydown or change events
+    ref https://spectrum.chat/testing-library/help/has-anyone-successfully-used-rtl-to-test[…]nts-on-a-draftjs-text-box~f1928053-9e53-407a-9be5-70babeb4b692
+        https://github.com/facebook/draft-js/issues/743
+ ***/
 
 describe('AshleyEditor', () => {
   it('renders the editor and expected elements are present', () => {
@@ -31,6 +38,107 @@ describe('AshleyEditor', () => {
     const linkButton = container.querySelector(
       'path[d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"]',
     );
+
     expect(linkButton).toBeInTheDocument();
+
+    // check if code button has been added to the toolbar plugin editor
+    const codeButton = container.querySelector(
+      'path[d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"]',
+    );
+    expect(codeButton).toBeInTheDocument();
+  });
+
+  it('loads AshleyEditor component with existing json content containing a code-block and an unstyled block', () => {
+    const target = document.createElement('input');
+    target.value = BlockMapFactory([
+      {
+        key: 'brt6g',
+        text: 'ce texte est ajouté dans code-block.\n',
+        type: 'code-block',
+      },
+      {
+        inlineStyleRanges: [
+          {
+            offset: 0,
+            length: 21,
+            style: 'BOLD',
+          },
+        ],
+        text: 'ce texte est en gras.',
+        type: 'unstyled',
+      },
+    ]);
+    const { container } = render(<AshleyEditor target={target} />);
+    // check that the content is now present in the editor
+    screen.getByText(/ce texte est ajouté dans code-block./i);
+    screen.getByText(/ce texte est en gras./i);
+
+    // validate that the block code-block is in the expected pre element with the expected draft-js class
+    // we use a selector on purpose to confirm that draft-js has been loaded
+    expect(
+      container.querySelector(
+        'pre.public-DraftStyleDefault-pre [data-text="true"]',
+      ),
+    ).toHaveTextContent('ce texte est ajouté dans code-block.');
+  });
+
+  it('updates the input loaded in AshleyEditor when we change the content of the editor', () => {
+    const target = document.createElement('input');
+    const { container } = render(<AshleyEditor target={target} />);
+    // select the draft-js editor
+    const editorNode = container.querySelector('.public-DraftEditor-content')!;
+    // paste text
+    const toBePasted = {
+      clipboardData: {
+        types: ['text/plain'],
+        getData: (type: string) => "Je suis dans l'éditeur !",
+      },
+    };
+    fireEvent(editorNode, createEvent.paste(editorNode, toBePasted));
+
+    // check that the text is now present
+    screen.getByText(/je suis dans l'éditeur !/i);
+
+    // control it has been added to the input.value
+    expect(target.value).toContain("Je suis dans l'éditeur !");
+  });
+
+  /*****
+   * draft-js default behaviour for code block is to create a new code block for each pasted line
+   * we test that the rewrite of handlePastedText is properly handled
+   */
+  it('pastes in a code-block and stays in the same draft-js code-block', () => {
+    const target = document.createElement('input');
+    target.value = BlockMapFactory([
+      {
+        key: 'brt6g',
+        text: 'Je suis ajouté comme code block !',
+        type: 'code-block',
+      },
+    ]);
+    const { container } = render(<AshleyEditor target={target} />);
+    // target the code block
+    const editorNode = container.querySelector(
+      'pre.public-DraftStyleDefault-pre [data-text="true"]',
+    )!;
+    const toBePasted = {
+      clipboardData: {
+        types: ['text/plain'],
+        getData: (type: string) => '<?php $i=100;?>',
+      },
+    };
+    fireEvent(editorNode, createEvent.paste(editorNode, toBePasted));
+    // check that text has been added in the editor
+    screen.getByText(/Je suis ajouté comme code block !<\?php \$i=100;\?>/i);
+    // check that it has been properly added in current code-block content
+    expect(target.value).toEqual(
+      BlockMapFactory([
+        {
+          key: 'brt6g',
+          text: 'Je suis ajouté comme code block !<?php $i=100;?>',
+          type: 'code-block',
+        },
+      ]),
+    );
   });
 });

--- a/src/frontend/js/draftjs-plugins/code-editor/index.ts
+++ b/src/frontend/js/draftjs-plugins/code-editor/index.ts
@@ -1,0 +1,98 @@
+/**
+ * Credits :
+ * Forked from https://github.com/withspectrum/draft-js-code-editor-plugin
+ * - added an unstyle block after key return is pressed. This is done by inserting a new
+ *   block when the split-block keyCommand is fired.
+ */
+
+import CodeUtils from 'draft-js-code';
+import Draft, {
+  ContentBlock,
+  EditorState,
+  KeyBindingUtil,
+  RichUtils,
+  DraftEditorCommand,
+} from 'draft-js';
+import { EditorPlugin, PluginFunctions } from '@draft-js-plugins/editor/lib';
+import React from 'react';
+import { List } from 'immutable';
+
+const createCodeEditorPlugin = (): EditorPlugin => {
+  return {
+    handleKeyCommand(
+      command: string,
+      editorState: EditorState,
+      eventTimeStamp: number,
+      { setEditorState }: PluginFunctions,
+    ) {
+      const newState = CodeUtils.hasSelectionInBlock(editorState)
+        ? CodeUtils.handleKeyCommand(editorState, command)
+        : RichUtils.handleKeyCommand(editorState, command);
+
+      if (newState) {
+        setEditorState(newState);
+        return 'handled';
+      }
+      return 'not-handled';
+    },
+    keyBindingFn(
+      evt: React.KeyboardEvent,
+      { getEditorState }: PluginFunctions,
+    ) {
+      return !CodeUtils.hasSelectionInBlock(getEditorState())
+        ? Draft.getDefaultKeyBinding(evt)
+        : (CodeUtils.getKeyBinding(evt) as DraftEditorCommand);
+    },
+    handleReturn(
+      evt: React.KeyboardEvent,
+      editorState: EditorState,
+      { setEditorState }: PluginFunctions,
+    ) {
+      if (!CodeUtils.hasSelectionInBlock(editorState)) return 'not-handled';
+      const selection = editorState.getSelection();
+      // Add an unstyle block after key return is pressed. Detect when the keyCommand is fired and split the block
+      if (selection.isCollapsed() && KeyBindingUtil.hasCommandModifier(evt)) {
+        const contentState = editorState.getCurrentContent();
+        const newBlock = new ContentBlock({
+          key: Draft.genKey(),
+          type: 'unstyled',
+          text: '',
+          characterList: List(),
+        });
+        const newBlockMap = contentState
+          .getBlockMap()
+          .set(newBlock.getKey(), newBlock);
+        const newState = Draft.EditorState.push(
+          editorState,
+          Draft.ContentState.createFromBlockArray(newBlockMap.toArray()).set(
+            'selectionAfter',
+            contentState.getSelectionAfter().merge({
+              anchorKey: newBlock.getKey(),
+              anchorOffset: 0,
+              focusKey: newBlock.getKey(),
+              focusOffset: 0,
+              isBackward: false,
+            }),
+          ) as Draft.ContentState,
+          'split-block',
+        );
+        setEditorState(newState);
+        return 'handled';
+      }
+      setEditorState(CodeUtils.handleReturn(evt, editorState));
+      return 'handled';
+    },
+    onTab(
+      evt: React.KeyboardEvent,
+      { getEditorState, setEditorState }: PluginFunctions,
+    ) {
+      const editorState = getEditorState();
+      if (!CodeUtils.hasSelectionInBlock(editorState)) return;
+
+      setEditorState(CodeUtils.onTab(evt, editorState));
+      return true;
+    },
+  };
+};
+
+export default createCodeEditorPlugin;

--- a/src/frontend/js/types/libs/draft-js-code/draft-js-code.d.ts
+++ b/src/frontend/js/types/libs/draft-js-code/draft-js-code.d.ts
@@ -1,0 +1,26 @@
+declare module 'draft-js-code' {
+  import { EditorState } from 'draft-js';
+
+  function getKeyBinding(event: React.KeyboardEvent): string;
+  function hasSelectionInBlock(editorState: EditorState): boolean;
+  function handleKeyCommand(
+    editorState: EditorState,
+    command: string,
+  ): EditorState;
+  function handleReturn(
+    event: React.KeyboardEvent,
+    editorState: EditorState,
+  ): EditorState;
+  function onTab(
+    event: React.KeyboardEvent,
+    editorState: EditorState,
+  ): EditorState;
+
+  export = {
+    getKeyBinding,
+    hasSelectionInBlock,
+    handleKeyCommand,
+    handleReturn,
+    onTab,
+  };
+}

--- a/src/frontend/js/utils/highlight.ts
+++ b/src/frontend/js/utils/highlight.ts
@@ -1,0 +1,9 @@
+import hljs from 'highlight.js';
+
+export const renderHighlight = () => {
+  document.querySelectorAll('.post-content pre code').forEach((block) => {
+    if (block instanceof HTMLElement) {
+      hljs.highlightBlock(block);
+    }
+  });
+};

--- a/src/frontend/js/utils/test/factories.ts
+++ b/src/frontend/js/utils/test/factories.ts
@@ -1,0 +1,17 @@
+import Draft from 'draft-js';
+
+export const BlockMapFactory = (blocks: object[]) => {
+  const defaultBlock = {
+    key: Draft.genKey(),
+    text: '',
+    type: 'unstyled',
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+    data: {},
+  };
+  return JSON.stringify({
+    blocks: blocks.map((block) => ({ ...defaultBlock, ...block })),
+    entityMap: {},
+  });
+};

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -26,6 +26,7 @@
     "@babel/polyfill": "7.12.1",
     "@babel/preset-env": "7.12.13",
     "@babel/preset-typescript": "7.12.13",
+    "@testing-library/dom": "7.29.4",
     "@testing-library/jest-dom": "5.11.9",
     "@testing-library/react": "11.2.5",
     "@types/draft-js": "0.10.44",
@@ -58,9 +59,11 @@
     "bootstrap": "4.6.0",
     "core-js": "3.8.3",
     "draft-js": "0.11.7",
+    "draft-js-code": "0.3.0",
     "draft-js-emoji-plugin": "2.1.3",
     "emojione": "4.5.0",
     "es6-shim": "0.35.6",
+    "highlight.js": "10.5.0",
     "react": "17.0.1",
     "react-dom": "17.0.1"
   }

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -17,6 +17,9 @@
 @import '@draft-js-plugins/static-toolbar/lib/plugin';
 @import '@draft-js-plugins/anchor/lib/plugin';
 
+//highlight code style
+@import 'highlight.js/styles/github';
+
 // Ashley forum specific style
 @import './objects/_editor';
 @import './objects/_emojis';

--- a/src/frontend/scss/objects/_editor.scss
+++ b/src/frontend/scss/objects/_editor.scss
@@ -66,3 +66,19 @@
   color: $link-color;
   text-decoration: underline;
 }
+
+.ashley-editor-widget {
+  .public-DraftStyleDefault-pre {
+    background-color: $gray-100;
+    border: 1px solid $gray-400;
+    display: block;
+    font-size: 0.9em;
+    line-height: 1.2;
+    margin: 0.5em 0;
+    padding: 20px;
+    width: 75%;
+    pre {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1135,7 +1135,7 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^7.28.1":
+"@testing-library/dom@7.29.4", "@testing-library/dom@^7.28.1":
   version "7.29.4"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.4.tgz#1647c2b478789621ead7a50614ad81ab5ae5b86c"
   integrity sha512-CtrJRiSYEfbtNGtEsd78mk1n1v2TUbeABlNIcOCJdDfkN5/JTOwQEbbQpoSRxGqzcWPgStMvJ4mNolSuBRv1NA==
@@ -2554,6 +2554,18 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+detect-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+  integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
+  dependencies:
+    repeating "^2.0.0"
+
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -2596,6 +2608,16 @@ dot-prop@^5.2.0:
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
   dependencies:
     is-obj "^2.0.0"
+
+draft-js-code@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/draft-js-code/-/draft-js-code-0.3.0.tgz#d955d134367baeee5844b57f897c8d848bc979c5"
+  integrity sha512-e/Rblaj1FvYzvQK45QHt8qAl5lBLFSHWPzNrF8Avv/8Bx0ZtPHD8ykCdazM2NjTvinZmPJ5dLoRHphgFQycasg==
+  dependencies:
+    detect-indent "^4.0.0"
+    detect-newline "^2.1.0"
+    ends-with "^0.2.0"
+    immutable "3.x"
 
 draft-js-emoji-plugin@2.1.3:
   version "2.1.3"
@@ -2675,6 +2697,11 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+ends-with@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ends-with/-/ends-with-0.2.0.tgz#2f9da98d57a50cfda4571ce4339000500f4e6b8a"
+  integrity sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o=
 
 enhanced-resolve@^5.7.0:
   version "5.7.0"
@@ -3296,6 +3323,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+highlight.js@10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.5.0.tgz#3f09fede6a865757378f2d9ebdcbc15ba268f98f"
+  integrity sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==
+
 hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
@@ -3360,6 +3392,11 @@ ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
   integrity sha1-SMptcvbGo68Aqa1K5odr44ieKwk=
+
+immutable@3.x:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
 
 immutable@~3.7.4:
   version "3.7.6"


### PR DESCRIPTION
## Purpose

The input field to add a message is based on the draftjs editor. We want to be able to add a code blocks via this editor.
Syntax highlighting as on github would be nice to have.
https://github.com/openfun/ashley/issues/68


## Proposal

- Add a "code block" button to the editor's toolbar that allows formatting part of a message as code

<img width="878" alt="Capture d’écran 2021-01-19 à 11 05 49" src="https://user-images.githubusercontent.com/76939263/105019407-55492680-5a46-11eb-9620-f9ae9c8c38b0.png">


- Auto-highlighting code displayed in the forum using a lib highlight.js that auto-detects the type of code and provides css.

<img width="1073" alt="Capture d’écran 2021-01-19 à 11 04 17" src="https://user-images.githubusercontent.com/76939263/105019236-29c63c00-5a46-11eb-96e8-f34e1a66c079.png">
