### PR TITLE
✨(back) limit forum listing to the current user LTIContext id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
  - fix serialization error in search index update
  - remove deprecated url in favor of re_path 
+ - prevent inactive users from authenticating via LTI
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
  - upgrade django-machina from 1.1.3 to 1.1.4
  - add button to insert quotes in the draftjs editor
+ - limit forum listing to the current user LTIContext id
 
 ### Fixed
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -170,7 +170,7 @@ class Base(Configuration):
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
         "dockerflow.django.middleware.DockerflowMiddleware",
-        "machina.apps.forum_permission.middleware.ForumPermissionMiddleware",
+        "ashley.machina_extensions.forum_permission.middleware.ForumPermissionMiddleware",
     ]
 
     AUTHENTICATION_BACKENDS = [
@@ -341,6 +341,9 @@ class Production(Base):
     configuration (and derived configurations):
     DJANGO_ALLOWED_HOSTS="foo.com,foo.fr"
     """
+
+    # Session storage engine
+    SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
     # Security
     ALLOWED_HOSTS = values.ListValue(None)

--- a/src/ashley/__init__.py
+++ b/src/ashley/__init__.py
@@ -11,3 +11,6 @@ ASHLEY_MAIN_TEMPLATE_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     "templates",
 )
+
+# Name of the session entry containing the current LTI context ID
+SESSION_LTI_CONTEXT_ID = "ltictx"

--- a/src/ashley/auth/backend.py
+++ b/src/ashley/auth/backend.py
@@ -60,7 +60,7 @@ class LTIBackend(ToolboxLTIBackend):
         )
         user_model = get_user_model()
         try:
-            return user_model.objects.get(
+            user = user_model.objects.get(
                 lti_consumer=lti_consumer, lti_remote_user_id=remote_user_id
             )
         except user_model.DoesNotExist:

--- a/src/ashley/machina_extensions/forum_permission/handler.py
+++ b/src/ashley/machina_extensions/forum_permission/handler.py
@@ -2,6 +2,7 @@
 This module defines a ``PermissionHandler`` abstraction that allows to
 implement filter or access logic related to forums.
 """
+from typing import Optional
 
 from machina.apps.forum_permission.handler import (
     PermissionHandler as BasePermissionHandler,
@@ -11,6 +12,28 @@ from machina.apps.forum_permission.handler import (
 class PermissionHandler(BasePermissionHandler):
     """Add ashley specific permission checks to the machina permission handler."""
 
+    def __init__(self):
+        """Constructor"""
+        super().__init__()
+        # This attribute is used to store the LTIContext of the current user.
+        # (see middleware.ForumPermission)
+        # It allows the permission checking functions to be aware of the current LTIContext
+        # we are scoped into, if any.
+        self.current_lti_context_id: Optional[int] = None
+
     def can_rename_forum(self, forum, user):
         """ Given a forum, checks whether the user can rename it. """
         return self._perform_basic_permission_check(forum, user, "can_rename_forum")
+
+    def forum_list_filter(self, qs, user):
+        """
+        Filters the given queryset in order to return a list of forums that
+        can be seen and read by the specified user (at least).
+
+        We override django machina's method to filter forums based on the
+        current LTI context of the User, if any.
+        """
+        forums_to_show = super().forum_list_filter(qs, user)
+        if self.current_lti_context_id:
+            return forums_to_show.filter(lti_contexts__id=self.current_lti_context_id)
+        return forums_to_show

--- a/src/ashley/machina_extensions/forum_permission/middleware.py
+++ b/src/ashley/machina_extensions/forum_permission/middleware.py
@@ -1,0 +1,30 @@
+"""Middleware declaration for the forum_permission machina app"""
+
+from machina.apps.forum_permission.middleware import (
+    ForumPermissionMiddleware as BaseForumPermissionMiddleware,
+)
+
+from ashley import SESSION_LTI_CONTEXT_ID
+
+
+class ForumPermissionMiddleware(BaseForumPermissionMiddleware):
+    """
+    Django Machina's ForumPermissionMiddleware attaches an instance of the
+    PermissionHandler to each request.
+
+    We override it to store the current LTI context ID (that is stored in
+    session), when it is available, in the permission handler.
+
+    Since machina permission checking functions are not aware of the request
+    object, this allows to use this information for permission checking.
+    """
+
+    def process_request(self, request):
+        super().process_request(request)
+
+        if request.user.is_authenticated:
+            current_lti_context_id = request.session.get(SESSION_LTI_CONTEXT_ID)
+            if current_lti_context_id:
+                request.forum_permission_handler.current_lti_context_id = (
+                    current_lti_context_id
+                )

--- a/src/ashley/views.py
+++ b/src/ashley/views.py
@@ -20,6 +20,7 @@ from machina.apps.forum_permission.viewmixins import (
 from machina.core.db.models import get_model
 from machina.core.loading import get_class
 
+from . import SESSION_LTI_CONTEXT_ID
 from .defaults import DEFAULT_FORUM_BASE_PERMISSIONS, DEFAULT_FORUM_ROLES_PERMISSIONS
 
 Forum = get_model("forum", "Forum")  # pylint: disable=C0103
@@ -48,6 +49,9 @@ class ForumLTIView(BaseLTIAuthView):
 
         # Synchronize the user groups related to the current LTI context
         context.sync_user_groups(self.request.user, lti_request.roles)
+
+        # Store the current user LTI context in session
+        self.request.session[SESSION_LTI_CONTEXT_ID] = context.id
 
         # Get or create the requested forum
         forum_uuid = self.kwargs["uuid"]

--- a/tests/ashley/lti_utils.py
+++ b/tests/ashley/lti_utils.py
@@ -1,0 +1,47 @@
+"""This package contains helper functions to build LTI requests"""
+
+from urllib.parse import unquote
+
+from oauthlib import oauth1
+
+CONTENT_TYPE = "application/x-www-form-urlencoded"
+
+
+def sign_parameters(passport, lti_parameters, url):
+    """
+
+    Args:
+        passport: The LTIPassport to use to sign the oauth request
+        lti_parameters: A dictionnary of parameters to sign
+        url: The LTI launch URL
+
+    Returns:
+        dict: The signed parameters
+    """
+
+    signed_parameters = lti_parameters.copy()
+    oauth_client = oauth1.Client(
+        client_key=passport.oauth_consumer_key, client_secret=passport.shared_secret
+    )
+    # Compute Authorization header which looks like:
+    # Authorization: OAuth oauth_nonce="80966668944732164491378916897",
+    # oauth_timestamp="1378916897", oauth_version="1.0", oauth_signature_method="HMAC-SHA1",
+    # oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"
+    _uri, headers, _body = oauth_client.sign(
+        url,
+        http_method="POST",
+        body=lti_parameters,
+        headers={"Content-Type": CONTENT_TYPE},
+    )
+
+    # Parse headers to pass to template as part of context:
+    oauth_dict = dict(
+        param.strip().replace('"', "").split("=")
+        for param in headers["Authorization"].split(",")
+    )
+
+    signature = oauth_dict["oauth_signature"]
+    oauth_dict["oauth_signature"] = unquote(signature)
+    oauth_dict["oauth_nonce"] = oauth_dict.pop("OAuth oauth_nonce")
+    signed_parameters.update(oauth_dict)
+    return signed_parameters

--- a/tests/ashley/machina_extensions/forum_permission/test_permission_handler.py
+++ b/tests/ashley/machina_extensions/forum_permission/test_permission_handler.py
@@ -1,0 +1,68 @@
+from django.test import TestCase
+from machina.apps.forum_permission.shortcuts import assign_perm
+
+from ashley import SESSION_LTI_CONTEXT_ID
+from ashley.factories import ForumFactory, LTIContextFactory, UserFactory
+
+
+class PermissionHandlerTestCase(TestCase):
+    """Test the ForumPermission middleware"""
+
+    def test_forum_list(self):
+        user = UserFactory()
+        lti_context_a = LTIContextFactory(lti_consumer=user.lti_consumer)
+        lti_context_b = LTIContextFactory(lti_consumer=user.lti_consumer)
+
+        # Create 2 forums for context A
+        forum_a1 = ForumFactory(name="Forum A1")
+        forum_a1.lti_contexts.add(lti_context_a)
+        forum_a2 = ForumFactory(name="Forum A2")
+        forum_a2.lti_contexts.add(lti_context_a)
+        # Create 2 forums for context B
+        forum_b1 = ForumFactory(name="Forum B1")
+        forum_b1.lti_contexts.add(lti_context_b)
+        forum_b2 = ForumFactory(name="Forum B2")
+        forum_b2.lti_contexts.add(lti_context_b)
+
+        # Grant read-only access for forums A1, A2 and B1 to our user
+        assign_perm("can_see_forum", user, forum_a1, True)
+        assign_perm("can_read_forum", user, forum_a1, True)
+        assign_perm("can_see_forum", user, forum_a2, True)
+        assign_perm("can_read_forum", user, forum_a2, True)
+        assign_perm("can_see_forum", user, forum_b1, True)
+        assign_perm("can_read_forum", user, forum_b1, True)
+
+        self.client.force_login(user, "ashley.auth.backend.LTIBackend")
+        session = self.client.session
+
+        # Make a request to get the forum list, with an empty session
+        response = self.client.get("/forum/")
+        # We should see all forums we have access to
+        self.assertContains(response, "Forum A1")
+        self.assertContains(response, "Forum A2")
+        self.assertContains(response, "Forum B1")
+        self.assertNotContains(response, "Forum B2")
+
+        # Update the client session to limit the user to the LTIContext A
+        # Make a request to get he forum list again
+        session[SESSION_LTI_CONTEXT_ID] = lti_context_a.id
+        session.save()
+        response = self.client.get("/forum/")
+
+        # We should see only forums related to LTIContext A
+        self.assertContains(response, "Forum A1")
+        self.assertContains(response, "Forum A2")
+        self.assertNotContains(response, "Forum B1")
+        self.assertNotContains(response, "Forum B2")
+
+        # Update the client session to limit the user to the LTIContext B
+        # Make a request to get he forum list again
+        session[SESSION_LTI_CONTEXT_ID] = lti_context_b.id
+        session.save()
+        response = self.client.get("/forum/")
+
+        # We should see only forum B1
+        self.assertNotContains(response, "Forum A1")
+        self.assertNotContains(response, "Forum A2")
+        self.assertContains(response, "Forum B1")
+        self.assertNotContains(response, "Forum B2")

--- a/tests/ashley/machina_extensions/forum_permission/test_permission_middleware.py
+++ b/tests/ashley/machina_extensions/forum_permission/test_permission_middleware.py
@@ -1,0 +1,86 @@
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory, TestCase
+
+from ashley import SESSION_LTI_CONTEXT_ID
+from ashley.factories import LTIContextFactory, UserFactory
+from ashley.machina_extensions.forum_permission.middleware import (
+    ForumPermissionMiddleware,
+)
+
+
+class ForumPermissionMiddlewareTestCase(TestCase):
+    """Test the ForumPermission middleware"""
+
+    def test_lti_context_id(self):
+        """
+        When the `SESSION_LTI_CONTEXT_ID` is set in the user session, it should
+        be injected into the PermissionHandler instance that is stored in the
+        request object.
+        """
+
+        user = UserFactory()
+        lti_context = LTIContextFactory(lti_consumer=user.lti_consumer)
+
+        # Generate a request
+        request = RequestFactory().get("/")
+
+        # Attach a user to the request
+        request.user = user
+
+        # Attach a session to the request
+        session_middleware = SessionMiddleware(lambda r: None)
+        session_middleware.process_request(request)
+
+        # Store the LTIContext id in the session
+        request.session[SESSION_LTI_CONTEXT_ID] = lti_context.id
+        self.assertEqual(request.session.get(SESSION_LTI_CONTEXT_ID), lti_context.id)
+
+        # Execute the ForumPermissionMiddleware on the request
+        permission_middleware = ForumPermissionMiddleware(lambda r: None)
+        permission_middleware.process_request(request)
+
+        # The permission handler instance should have been injected, with the
+        # right current_lti_context_id
+        self.assertEqual(
+            request.forum_permission_handler.current_lti_context_id, lti_context.id
+        )
+
+    def test_lti_context_id_anonymous(self):
+        """
+        The ForumPermissionMiddleware should not inject any LTIContext id in
+        the permission handler for request made by anonymous users.
+        """
+        lti_context = LTIContextFactory()
+
+        # Generate an anonymous request (with no LTIContext ID in session)
+        request_without_lti_context = RequestFactory().get("/")
+        request_without_lti_context.user = AnonymousUser()
+        session_middleware = SessionMiddleware(lambda r: None)
+        session_middleware.process_request(request_without_lti_context)
+        permission_middleware = ForumPermissionMiddleware(lambda r: None)
+        permission_middleware.process_request(request_without_lti_context)
+
+        # The permission handler should have been injected, without the current_lti_context_id
+        self.assertIsNotNone(request_without_lti_context.forum_permission_handler)
+        self.assertIsNone(
+            request_without_lti_context.forum_permission_handler.current_lti_context_id
+        )
+
+        # Generate an anonymous request (with a LTIContext ID in session)
+        request_with_lti_context = RequestFactory().get("/")
+        request_with_lti_context.user = AnonymousUser()
+        session_middleware = SessionMiddleware(lambda r: None)
+        session_middleware.process_request(request_with_lti_context)
+        request_with_lti_context.session[SESSION_LTI_CONTEXT_ID] = lti_context.id
+        self.assertEqual(
+            request_with_lti_context.session.get(SESSION_LTI_CONTEXT_ID), lti_context.id
+        )
+        permission_middleware = ForumPermissionMiddleware(lambda r: None)
+        permission_middleware.process_request(request_with_lti_context)
+
+        # The permission handler should have been injected, without the current_lti_context_id
+        self.assertIsNotNone(request_with_lti_context.forum_permission_handler)
+        self.assertIsNone(
+            request_with_lti_context.forum_permission_handler.current_lti_context_id
+        )

--- a/tests/ashley/test_forum_lti_view.py
+++ b/tests/ashley/test_forum_lti_view.py
@@ -1,0 +1,192 @@
+"""Test suite for ashley ForumLTIView."""
+
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.test import TestCase
+from lti_toolbox.factories import LTIConsumerFactory, LTIPassportFactory
+from machina.core.db.models import get_model
+
+from ashley import SESSION_LTI_CONTEXT_ID
+from ashley.factories import UserFactory
+
+from tests.ashley.lti_utils import CONTENT_TYPE, sign_parameters
+
+Forum = get_model("forum", "Forum")
+LTIContext = get_model("ashley", "LTIContext")
+
+
+class ForumLTIViewTestCase(TestCase):
+    """Test the ForumLTIView class"""
+
+    def test_post_with_valid_lti_launch_request(self):
+        """A user should be able to authenticate via a LTI launch request signed by
+        a trusted consumer and passport."""
+
+        consumer = LTIConsumerFactory(slug="consumer")
+        passport = LTIPassportFactory(title="consumer1_passport1", consumer=consumer)
+
+        forum_uuid = "8bb319aa-f3cf-4509-952c-c4bd0fb42fd7"
+        context_id = "course-v1:testschool+login+0001"
+
+        # Build the LTI launch request
+        lti_parameters = {
+            "user_id": "643f1625-f240-4a5a-b6eb-89b317807963",
+            "lti_message_type": "basic-lti-launch-request",
+            "lti_version": "LTI-1p0",
+            "resource_link_id": "aaa",
+            "context_id": context_id,
+            "lis_person_contact_email_primary": "ashley@example.com",
+            "lis_person_sourcedid": "testuser",
+            "launch_presentation_locale": "en",
+            "roles": "Instructor",
+        }
+        url = f"http://testserver/lti/forum/{forum_uuid}"
+        signed_parameters = sign_parameters(passport, lti_parameters, url)
+
+        response = self.client.post(
+            f"/lti/forum/{forum_uuid}",
+            data=urlencode(signed_parameters),
+            content_type=CONTENT_TYPE,
+        )
+
+        # A LTIContext and a Forum should have been created
+        context = LTIContext.objects.get(lti_id=context_id)
+        forum = Forum.objects.get(lti_id=forum_uuid)
+
+        # The response should be a redirection to the forum URL
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(f"/forum/forum/{forum.slug}-{forum.id}/", response.url)
+
+        # Our current LTIContext id should have been injected in the user session
+        self.assertEqual(context.id, self.client.session.get(SESSION_LTI_CONTEXT_ID))
+
+        # The launch_presentation_locale should be set in the language cookie
+        self.assertEqual(
+            "en", response.client.cookies[settings.LANGUAGE_COOKIE_NAME].value
+        )
+
+    def test_post_with_an_inactive_user(self):
+        """An inactive user should not be allowed to authenticate via a valid LTI request"""
+
+        user = UserFactory(is_active=False)
+        passport = LTIPassportFactory(
+            title="consumer1_passport1", consumer=user.lti_consumer
+        )
+
+        forum_uuid = "8bb319aa-f3cf-4509-952c-c4bd0fb42fd7"
+        context_id = "course-v1:testschool+login+0001"
+
+        # Build the LTI launch request
+        lti_parameters = {
+            "user_id": "643f1625-f240-4a5a-b6eb-89b317807963",
+            "lti_message_type": "basic-lti-launch-request",
+            "lti_version": "LTI-1p0",
+            "resource_link_id": "aaa",
+            "context_id": context_id,
+            "lis_person_contact_email_primary": "inactive_test_user@example.com",
+            "lis_person_sourcedid": user.public_username,
+            "launch_presentation_locale": "en",
+            "roles": "Instructor",
+        }
+        url = f"http://testserver/lti/forum/{forum_uuid}"
+        signed_parameters = sign_parameters(passport, lti_parameters, url)
+
+        response = self.client.post(
+            f"/lti/forum/{forum_uuid}",
+            data=urlencode(signed_parameters),
+            content_type=CONTENT_TYPE,
+        )
+
+        self.assertEqual(403, response.status_code)
+
+    def test_get(self):
+        """The GET method is not allowed to sign in"""
+
+        consumer = LTIConsumerFactory(slug="consumer")
+        passport = LTIPassportFactory(title="consumer1_passport1", consumer=consumer)
+
+        forum_uuid = "8bb319aa-f3cf-4509-952c-c4bd0fb42fd7"
+        context_id = "course-v1:testschool+login+0001"
+
+        # Build the LTI launch request
+        lti_parameters = {
+            "user_id": "643f1625-f240-4a5a-b6eb-89b317807963",
+            "lti_message_type": "basic-lti-launch-request",
+            "lti_version": "LTI-1p0",
+            "resource_link_id": "aaa",
+            "context_id": context_id,
+            "lis_person_contact_email_primary": "ashley@example.com",
+            "lis_person_sourcedid": "testuser",
+            "launch_presentation_locale": "en",
+            "roles": "Instructor",
+        }
+        url = f"http://testserver/lti/forum/{forum_uuid}"
+        signed_parameters = sign_parameters(passport, lti_parameters, url)
+
+        response = self.client.get(
+            f"/lti/forum/{forum_uuid}",
+            data=signed_parameters,
+            content_type=CONTENT_TYPE,
+        )
+        self.assertEqual(405, response.status_code)
+
+    def test_put(self):
+        """The PUT method is not allowed to sign in"""
+        consumer = LTIConsumerFactory(slug="consumer")
+        passport = LTIPassportFactory(title="consumer1_passport1", consumer=consumer)
+
+        forum_uuid = "8bb319aa-f3cf-4509-952c-c4bd0fb42fd7"
+        context_id = "course-v1:testschool+login+0001"
+
+        # Build the LTI launch request
+        lti_parameters = {
+            "user_id": "643f1625-f240-4a5a-b6eb-89b317807963",
+            "lti_message_type": "basic-lti-launch-request",
+            "lti_version": "LTI-1p0",
+            "resource_link_id": "aaa",
+            "context_id": context_id,
+            "lis_person_contact_email_primary": "ashley@example.com",
+            "lis_person_sourcedid": "testuser",
+            "launch_presentation_locale": "en",
+            "roles": "Instructor",
+        }
+        url = f"http://testserver/lti/forum/{forum_uuid}"
+        signed_parameters = sign_parameters(passport, lti_parameters, url)
+
+        response = self.client.put(
+            f"/lti/forum/{forum_uuid}",
+            data=urlencode(signed_parameters),
+            content_type=CONTENT_TYPE,
+        )
+        self.assertEqual(405, response.status_code)
+
+    def test_delete(self):
+        """The DELETE method is not allowed to sign in"""
+        consumer = LTIConsumerFactory(slug="consumer")
+        passport = LTIPassportFactory(title="consumer1_passport1", consumer=consumer)
+
+        forum_uuid = "8bb319aa-f3cf-4509-952c-c4bd0fb42fd7"
+        context_id = "course-v1:testschool+login+0001"
+
+        # Build the LTI launch request
+        lti_parameters = {
+            "user_id": "643f1625-f240-4a5a-b6eb-89b317807963",
+            "lti_message_type": "basic-lti-launch-request",
+            "lti_version": "LTI-1p0",
+            "resource_link_id": "aaa",
+            "context_id": context_id,
+            "lis_person_contact_email_primary": "ashley@example.com",
+            "lis_person_sourcedid": "testuser",
+            "launch_presentation_locale": "en",
+            "roles": "Instructor",
+        }
+        url = f"http://testserver/lti/forum/{forum_uuid}"
+        signed_parameters = sign_parameters(passport, lti_parameters, url)
+
+        response = self.client.delete(
+            f"/lti/forum/{forum_uuid}",
+            data=urlencode(signed_parameters),
+            content_type=CONTENT_TYPE,
+        )
+        self.assertEqual(405, response.status_code)


### PR DESCRIPTION
## Purpose

When a user is connected to Ashley via LTI, he can see and interact
with all forums he has access to, based on its group membership.

It can be confusing for the user, because he comes from a specific LTI
context and he does not expect to see information related to other
LTI contexts.

In addition to that, group membership synchronization is made during
the LTI authentication process. And it only synchronizes groups for the
current LTI context. So, if we let users access to resources related
to other LTI contexts, we cannot guarantee that user permissions are
correct and it can lead to security issues.

## Proposal

- [x] After LTI authentication, store the current LTI context id in session
- [x] Override django-machina PermissionHandler to hide forums not related to the current LTI context

