### PR TITLE
🎨(test) implement simple html content tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,8 @@ dev =
     pytest-cov==2.11.1
     pytest-django==4.1.0
     pytest==6.2.2
+    django-with-asserts==0.0.1
+
 ci =
     twine==3.3.0
 sandbox =

--- a/src/ashley/templates/partials/user_icon.html
+++ b/src/ashley/templates/partials/user_icon.html
@@ -1,8 +1,9 @@
 {% load i18n %}
 {% load custom_tags %}
-
+{% spaceless %}
 {% if topic|is_user_instructor:user %}
     <i class="icon_writer fas fa-award" aria-hidden="true" title="{%trans 'Instructor'%}">
     <span class="sr-only">{%trans 'Instructor'%}</span>
     </i>
 {% endif %}
+{% endspaceless %}


### PR DESCRIPTION
## Purpose

Testing the render of html for the reliability of the project
is essential. Writing these tests in the most simpliest way
is a key point on expanding and maintaining them. We use an
helper dependencie django-with-asserts to help us on redacting
them.

## Proposal

Adding the dependencie django-with-asserts and rewrite the test that target specific element in html