### PR TITLE
🗑(sandbox) remove deprecated url in favor of re_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
  - fix serialization error in search index update
+ - remove deprecated url in favor of re_path 
 
 ### Added
 

--- a/sandbox/dev_tools/urls.py
+++ b/sandbox/dev_tools/urls.py
@@ -1,18 +1,17 @@
 """URLs for the dev_tools django application."""
-from django.conf.urls import url
-from django.urls import reverse_lazy
+from django.urls import re_path, reverse_lazy
 from django.views.generic import RedirectView
 
 from . import views
 
 urlpatterns = [
-    url(
+    re_path(
         r"^$",
         RedirectView.as_view(
             url=reverse_lazy("dev_tools.views.consumer"), permanent=False
         ),
     ),
-    url(r"^consumer$", views.dev_consumer, name="dev_tools.views.consumer"),
+    re_path(r"^consumer$", views.dev_consumer, name="dev_tools.views.consumer"),
 ]
 
 #


### PR DESCRIPTION
## Purpose

Django 3.1 version have introduced deprecated method
RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor
of django.urls.re_path()


## Proposal

Update the code to follow new recommendations and replace  django.conf.urls.url() by django.urls.re_path()

