### PR TITLE
(models) enforce integrity between User and LTIContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - fix serialization error in search index update
  - remove deprecated url in favor of re_path 
  - prevent inactive users from authenticating via LTI
+ - prevent linking a User to a LTIContext related to different LTI Consumer
 
 ### Added
 

--- a/src/ashley/models.py
+++ b/src/ashley/models.py
@@ -4,6 +4,7 @@ from typing import List
 
 from django.contrib.auth.models import AbstractUser as DjangoAbstractUser
 from django.contrib.auth.models import Group
+from django.core.exceptions import PermissionDenied
 from django.db import models
 from django.db.models import Model
 from django.utils.translation import gettext_lazy as _
@@ -139,6 +140,11 @@ class AbstractLTIContext(Model):
         """
         Synchronize the group membership of a user for this LTI Context
         """
+        # Control user is part of this lti_context
+        if user.lti_consumer_id != self.lti_consumer_id:
+            raise PermissionDenied(
+                ("The User and LTIContext must be part of the same LTI Consumer")
+            )
 
         current_groups = list(user.groups.filter(name__startswith=self.base_group_name))
         target_groups = self.get_role_groups(roles) + [self.get_base_group()]


### PR DESCRIPTION

## Purpose

Currently with the method sync_user_group we can add groups to the user even if this one is not part of the lticontext. This shouldn't be allowed. 

## Proposal

We control that user is part of the lticontext before adding groups.

