### PR TITLE
🐛(frontend) handle error invalid configuration jest

### DIFF
--- a/src/frontend/jest.config.js
+++ b/src/frontend/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   setupFilesAfterEnv: ['./testSetup.ts'],
   testMatch: [__dirname + '/js/**/*.spec.+(ts|tsx|js)'],
   testURL: 'https://localhost',
+  transformIgnorePatterns: ['node_modules/(?!(lodash-es)/)'],
 };


### PR DESCRIPTION

## Purpose

A runtime error happens loading lodash-es module and fails front tests. This
lib is published as untranspiled.


## Proposal
 We configure jest to allow transpiling this
specific module.
