### PR TITLE
🚚(frontend) clean built frontend files before each build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ jobs:
           name: List builds
           command: |
             echo "== Javascript =="
-            ls ../ashley/static/ashley/js/*.js
+            ls ../ashley/static/ashley/js/build/*.js
             echo "== CSS =="
             ls ../ashley/static/ashley/css/*.css
             echo "== Webfonts =="
@@ -367,7 +367,7 @@ jobs:
       - persist_to_workspace:
           root: ~/fun
           paths:
-            - src/ashley/static/ashley/js/*.js
+            - src/ashley/static/ashley/js/**/*.js
             - src/ashley/static/ashley/css/*.css
             - src/ashley/static/ashley/font/*
   lint-front:

--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,8 @@ db.sqlite3
 
 # Font-end
 **/node_modules
+
+# Assets
+src/ashley/static/ashley/js
+src/ashley/static/ashley/css
+src/ashley/static/ashley/font

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Clean built frontend files before each build
+
 ## [1.0.0-beta.5] - 2020-03-01
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ COPY ./src/ashley /builder/src/ashley/
 
 # Copy distributed application's statics
 COPY --from=front-builder \
-    /builder/src/ashley/static/ashley/js/*.js \
-    /builder/src/ashley/static/ashley/js/
+    /builder/src/ashley/static/ashley/js \
+    /builder/src/ashley/static/ashley/js
 COPY --from=front-builder \
     /builder/src/ashley/static/ashley/css/main.css \
     /builder/src/ashley/static/ashley/css/main.css

--- a/src/ashley/templates/board_base.html
+++ b/src/ashley/templates/board_base.html
@@ -48,5 +48,5 @@
 
 {% block js %}
     {{ block.super }}
-    <script src="{% static 'ashley/js/ashley.js' %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static 'ashley/js/build/ashley.js' %}" type="text/javascript" charset="utf-8"></script>
 {% endblock js %}

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -11,8 +11,10 @@ module.exports = {
   // is on AWS.
   output: {
     filename: 'ashley.js',
-    path: __dirname + '/../ashley/static/ashley/js',
+    path: __dirname + '/../ashley/static/ashley/js/build',
     chunkFilename: '[id].[hash].index.js',
+    // Clean output directory before generate new files
+    clean: true,
   },
 
   // Enable sourcemaps for debugging webpack's output.


### PR DESCRIPTION
## Purpose

Webpack uses hashes to name files it generates. But currently, old files stay in place. So after several builds, we can have a js folder with a very large amount of files which is not efficient and furthermore can produce issues and slow down script executions.

In order to clean these files before each build, we need to put them in a dedicated directory to not remove
other js scripts placed in `static/js` directory.

To optimize the build of docker, we ignore `assets` files.

## Proposal

- [x] Generate frontend scripts into a dedicated `build` folder
- [x] Clean this new folder before each build
- [x] Ignore assets files for docker
