### PR TITLE
🗑️(test) remove lib to test simple html content

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,8 @@ dev =
     pytest-cov==2.11.1
     pytest-django==4.2.0
     pytest==6.2.3
-    django-with-asserts==0.0.1
+    lxml==4.6.3
+    cssselect==1.1.0
 
 ci =
     twine==3.4.1

--- a/tests/ashley/test_templatetags_custom_tags.py
+++ b/tests/ashley/test_templatetags_custom_tags.py
@@ -2,14 +2,13 @@
 import logging
 from typing import List
 
+import lxml.html  # nosec
 from django.template import Context, Template
 from django.test import TestCase
-from django.test.html import parse_html
 from django.urls import reverse
-from lxml import etree
+from lxml import etree  # nosec
 from machina.apps.forum_permission.shortcuts import assign_perm
 from machina.core.loading import get_class
-from with_asserts.mixin import AssertHTMLMixin
 
 from ashley.defaults import (
     DEFAULT_FORUM_BASE_PERMISSIONS,
@@ -31,7 +30,7 @@ get_forum_member_display_name = get_class(
 logger = logging.getLogger(__name__)
 
 
-class TestIsUserInstructorTag(TestCase, AssertHTMLMixin):
+class TestIsUserInstructorTag(TestCase):
     """
     Integration tests to validate that the filter is_user_instructor
     can detect if user is instructor of a forum
@@ -149,62 +148,62 @@ class TestIsUserInstructorTag(TestCase, AssertHTMLMixin):
 
         # accessing forum view
         response = self.client.get(reverse("forum:index"))
-        with self.assertHTML(response, ".forum-last-post") as (html,):
-            fragment = parse_html(str(etree.tostring(html)))
-            # control that the instructor's icon is present
-            self.assertTrue(
-                parse_html(
-                    '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
-                    '<span class="sr-only">Instructor</span>'
-                    "</i>"
-                )
-                in fragment
+        html = lxml.html.fromstring(response.content)
+        forum_last_post = str(etree.tostring(html.cssselect(".forum-last-post")[0]))
+        # control that the instructor's icon is present
+        self.assertTrue(
+            (
+                '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
+                '<span class="sr-only">Instructor</span>'
+                "</i>"
             )
-            # control that it's the right user's profil link
-            self.assertTrue(
-                parse_html(f'<a href="/forum/member/profile/{user1.id}/">Valéry</a>')
-                in fragment
-            )
+            in forum_last_post
+        )
+        # control that it's the right user's profile link
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user1.id}/">Val&#233;ry</a>')
+            in forum_last_post
+        )
 
         # accessing forum topic listing view
         response = self.client.get(
             reverse("forum:forum", kwargs={"slug": forum.slug, "pk": forum.pk})
         )
+        html = lxml.html.fromstring(response.content)
         # check that the topic creation writer contains the icon for instructor's role
-        with self.assertHTML(response, ".topic-created") as (html,):
-            fragment = parse_html(str(etree.tostring(html)))
-            # control that the instructor's icon is present
-            self.assertTrue(
-                parse_html(
-                    '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
-                    '<span class="sr-only">Instructor</span>'
-                    "</i>"
-                )
-                in fragment
+        topic_created = str(etree.tostring(html.cssselect(".topic-created")[0]))
+        # control that the instructor's icon is present
+        self.assertTrue(
+            (
+                '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
+                '<span class="sr-only">Instructor</span>'
+                "</i>"
             )
-            # control that it's the right user's profil link
-            self.assertTrue(
-                parse_html(f'<a href="/forum/member/profile/{user1.id}/">Valéry</a>')
-                in fragment
-            )
+            in topic_created
+        )
+        # control that it's the right user's profile link
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user1.id}/">Val&#233;ry</a>')
+            in topic_created
+        )
 
         # check that the last post creation writer contains the icon for instructor's role
-        with self.assertHTML(response, ".topic-last-post") as (html,):
-            fragment = parse_html(str(etree.tostring(html)))
-            # control that the instructor's icon is present
-            self.assertTrue(
-                parse_html(
-                    '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
-                    '<span class="sr-only">Instructor</span>'
-                    "</i>"
-                )
-                in fragment
+        html = lxml.html.fromstring(response.content)
+        topic_last_post = str(etree.tostring(html.cssselect(".topic-last-post")[0]))
+        # control that the instructor's icon is present
+        self.assertTrue(
+            (
+                '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
+                '<span class="sr-only">Instructor</span>'
+                "</i>"
             )
-            # control that it's the right user's profil link
-            self.assertTrue(
-                parse_html(f'<a href="/forum/member/profile/{user1.id}/">Valéry</a>')
-                in fragment
-            )
+            in topic_last_post
+        )
+        # control that it's the right user's profile link
+        self.assertTrue(
+            f'<a href="/forum/member/profile/{user1.id}/">Val&#233;ry</a>'
+            in topic_last_post
+        )
 
         # user2 add a post to the topic, last message is now from a student
         PostFactory.create(
@@ -216,35 +215,31 @@ class TestIsUserInstructorTag(TestCase, AssertHTMLMixin):
         response = self.client.get(
             reverse("forum:forum", kwargs={"slug": forum.slug, "pk": forum.pk})
         )
-
-        with self.assertHTML(response, ".topic-created") as (html,):
-            fragment = parse_html(str(etree.tostring(html)))
-            # control that the instructor's icon is present
-            self.assertTrue(
-                parse_html(
-                    '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
-                    '<span class="sr-only">Instructor</span>'
-                    "</i>"
-                )
-                in fragment
+        html = lxml.html.fromstring(response.content)
+        topic_created = str(etree.tostring(html.cssselect(".topic-created")[0]))
+        # control that the instructor's icon is present
+        self.assertTrue(
+            (
+                '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
+                '<span class="sr-only">Instructor</span>'
+                "</i>"
             )
-            # control that it's the right profil link
-            self.assertTrue(
-                parse_html(f'<a href="/forum/member/profile/{user1.id}/">Valéry</a>')
-                in fragment
-            )
+            in topic_created
+        )
+        # control that it's the right user's profile link
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user1.id}/">Val&#233;ry</a>')
+            in topic_created
+        )
 
-        # check that the last post creation writer is not the previous one with the icon
-        with self.assertHTML(response, ".topic-last-post") as (html,):
-            fragment = parse_html(str(etree.tostring(html)))
-            # check that there's no more icon as the post has been created by a student
-            self.assertFalse(parse_html("Instructor") in fragment)
-
-            # control that it's the right profil link
-            self.assertTrue(
-                parse_html(f'<a href="/forum/member/profile/{user2.id}/">François</a>')
-                in fragment
-            )
+        topic_last_post = str(etree.tostring(html.cssselect(".topic-last-post")[0]))
+        # check that there's no more icon as the post has been created by a student
+        self.assertFalse("Instructor" in topic_last_post)
+        # control that it's the right user's profile link
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user2.id}/">Fran&#231;ois</a>')
+            in topic_last_post
+        )
 
         # accessing forum view
         response = self.client.get(reverse("forum:index"))
@@ -267,29 +262,27 @@ class TestIsUserInstructorTag(TestCase, AssertHTMLMixin):
         response = self.client.get(
             f"/forum/forum/{forum.slug}-{forum.pk}/topic/{topic1.slug}-{topic1.pk}/post/create/"
         )
+        html = lxml.html.fromstring(response.content)
         # check that for the posts in this topic we have the one from the instructor with the icon
-        with self.assertHTML(response, ".text-muted") as (
-            first_post,
-            second_post,
-        ):
-            # check that for the message on first position there is no icon for the student
-            html_first_post = parse_html(str(etree.tostring(first_post)))
-            self.assertFalse(parse_html("Instructor") in html_first_post)
-            self.assertTrue(
-                parse_html(f'<a href="/forum/member/profile/{user2.id}/">François</a>')
-                in html_first_post
+
+        # check that for the message on first position there is no icon for the student
+        html_first_post = str(etree.tostring(html.cssselect(".text-muted")[0]))
+        self.assertFalse("Instructor" in html_first_post)
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user2.id}/">Fran&#231;ois</a>')
+            in html_first_post
+        )
+        # check that for the second message we have the instructor's icon
+        html_second_post = str(etree.tostring(html.cssselect(".text-muted")[1]))
+        self.assertTrue(
+            (
+                '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
+                '<span class="sr-only">Instructor</span>'
+                "</i>"
             )
-            # check that for the second message we have the instructor's icon
-            html_second_post = parse_html(str(etree.tostring(second_post)))
-            self.assertTrue(
-                parse_html(
-                    '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
-                    '<span class="sr-only">Instructor</span>'
-                    "</i>"
-                )
-                in html_second_post
-            )
-            self.assertTrue(
-                parse_html(f'<a href="/forum/member/profile/{user1.id}/">Valéry</a>')
-                in html_second_post
-            )
+            in html_second_post
+        )
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user1.id}/">Val&#233;ry</a>')
+            in html_second_post
+        )


### PR DESCRIPTION
## Purpose

To test html content in backend tests, we've used a deprecated library that
hasn't been updated since 2013. We've replaced it by using directly lxml and
cssselect to clarify the code.


## Proposal

remove django-with-asserts and adding lxml and cssselect and rewrite tests with these two libs directly
