### PR TITLE
🔧(front) upgrade node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ jobs:
       # Activate docker-in-docker (with layers caching enabled)
       - setup_remote_docker:
           docker_layer_caching: true
+          version: 19.03.13
       # Each image is tagged with the current git commit sha1 to avoid collisions in parallel builds.
       - run:
           name: Build production image
@@ -310,15 +311,15 @@ jobs:
   # ---- Front-end jobs ----
   build-front:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     working_directory: ~/fun/src/frontend
     steps:
       - checkout:
           path: ~/fun
       - restore_cache:
           keys:
-            - v1-front-dependencies-{{ checksum "yarn.lock" }}
-            - v1-front-dependencies-
+            - v2-front-dependencies-{{ checksum "yarn.lock" }}
+            - v2-front-dependencies-
       # If the yarn.lock file is not up-to-date with the package.json file,
       # using the --frozen-lockfile should fail.
       - run:
@@ -340,19 +341,19 @@ jobs:
       - save_cache:
           paths:
             - ./node_modules
-          key: v1-front-dependencies-{{ checksum "yarn.lock" }}
+          key: v2-front-dependencies-{{ checksum "yarn.lock" }}
 
   build-front-production:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     working_directory: ~/fun/src/frontend
     steps:
       - checkout:
           path: ~/fun
       - restore_cache:
           keys:
-            - v1-front-dependencies-{{ checksum "yarn.lock" }}
-            - v1-front-dependencies-
+            - v2-front-dependencies-{{ checksum "yarn.lock" }}
+            - v2-front-dependencies-
       - run:
           name: Build front-end application in production mode
           command: yarn build-production
@@ -379,14 +380,14 @@ jobs:
             - src/ashley/static/ashley/font/*
   lint-front:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     working_directory: ~/fun/src/frontend
     steps:
       - checkout:
           path: ~/fun
       - restore_cache:
           keys:
-            - v1-front-dependencies-{{ checksum "yarn.lock" }}
+            - v2-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Lint code with tslint
           command: yarn lint
@@ -396,14 +397,14 @@ jobs:
 
   test-front:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     working_directory: ~/fun/src/frontend
     steps:
       - checkout:
           path: ~/fun
       - restore_cache:
           keys:
-            - v1-front-dependencies-{{ checksum "yarn.lock" }}
+            - v2-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Run tests
           # Circle CI needs the tests to be run sequentially, otherwise it hangs. See Jest docs below:
@@ -412,7 +413,7 @@ jobs:
 
   test-front-package:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     working_directory: ~/wrk
     steps:
       - checkout:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
  - Clean built frontend files before each build
+ - Upgrade node to version 14, the current LTS
 
 ### Added
  

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM python:3.8-slim as base
 RUN pip install --upgrade pip
 
 # ---- Front-end builder image ----
-FROM node:10 as front-builder
+FROM node:14 as front-builder
 
 # Copy frontend app sources
 COPY ./src/frontend /builder/src/frontend

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -50,7 +50,7 @@
     "intl-pluralrules": "1.2.2",
     "jest": "26.6.3",
     "lodash-es": "4.17.21",
-    "node-sass": "5.0.0",
+    "node-sass": "6.0.0",
     "nodemon": "2.0.7",
     "prettier": "2.2.1",
     "source-map-loader": "2.0.1",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -5575,10 +5575,10 @@ node-releases@^1.1.70:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.70.tgz#66e0ed0273aa65666d7fe78febe7634875426a08"
   integrity sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==
 
-node-sass@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-5.0.0.tgz#4e8f39fbef3bac8d2dc72ebe3b539711883a78d2"
-  integrity sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==
+node-sass@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-6.0.0.tgz#f30da3e858ad47bfd138bc0e0c6f924ed2f734af"
+  integrity sha512-GDzDmNgWNc9GNzTcSLTi6DU6mzSPupVJoStIi7cF3GjwSE9q1cVakbvAAVSt59vzUjV9JJoSZFKoo9krbjKd2g==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION

## Purpose

Docker-compose uses the last node version : node 14. Circle and docker config
files are using the version 10 of node. Node 10 has no compatibility anymore
with some packages. To keep the project updated and to have all the versions
homogenized, an upgrade of node version to version 14 is needed in config files.


## Proposal

Update node version to node 14 and update node dependency when needed
