### PR TITLE
🩹(factory) fix import user model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
  - Clean built frontend files before each build
  - Upgrade node to version 14, the current LTS
+ - Fix import of the user model in the factory
 
 ### Added
  

--- a/src/ashley/factories.py
+++ b/src/ashley/factories.py
@@ -2,6 +2,7 @@
 import json
 
 import factory
+from django.contrib.auth import get_user_model
 from django.utils.text import slugify
 from factory.django import DjangoModelFactory
 from faker import Faker
@@ -14,7 +15,7 @@ Forum = get_model("forum", "Forum")  # pylint: disable=C0103
 LTIContext = get_model("ashley", "LTIContext")  # pylint: disable=C0103
 Post = get_model("forum_conversation", "Post")  # pylint: disable=C0103
 Topic = get_model("forum_conversation", "Topic")  # pylint: disable=C0103
-User = get_model("ashley", "User")  # pylint: disable=C0103
+User = get_user_model()
 
 
 class UserFactory(DjangoModelFactory):


### PR DESCRIPTION
## Purpose

The proper way to import the user model is by calling get_user_model() method.
To avoid any confusion, we simply fix this import into our factory.


## Proposal

Correct the import by using get_user_model method