### PR TITLE
🔧(circle) target docker version for hub task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,7 @@ jobs:
       # Activate docker-in-docker (with layers caching enabled)
       - setup_remote_docker:
           docker_layer_caching: true
+          version: 19.03.13
       - run:
           name: Build production image (using cached layers)
           command: docker build -t ashley:${CIRCLE_SHA1} --target production .


### PR DESCRIPTION
## Purpose

Node version has been upgraded to version 14 in the previous commit 5196917
For circle task to work properly with node 14, we need to clearly specify
the docker version.

## Proposal

Specifie docker version
