### PR TITLE
🔧(setup.cfg) target elasticsearch version 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     django-machina==1.1.4
     draftjs_exporter==4.1.2
     djangorestframework==3.12.2
-    elasticsearch>=5.0.0,<6.0.0 # pyup: >=5.0.0,<6.0.0
+    elasticsearch==5.*
     oauthlib>=3.0.0
 package_dir =
     =src


### PR DESCRIPTION
## Purpose

Renovate service auto updates python packages used in Ashley depending on
the setup.cfg file. The way it's actually written in this config file,
doesn't constrain elasticsearch's version between v5 and v6. Ashley is
meant to work with the latest release of version 5 of elasticsearch. We
target directly this version by using the pattern 5.*.
The way it's written now makes renovate update the file to elasticsearch version 8 which is not compatible with ashley elasticsearch>=5.0.0,<8.0.0 # pyup: >=5.0.0,<6.0.0

## Proposal

Write differently the target to elasticsearch's version
https://www.python.org/dev/peps/pep-0440/#inclusive-ordered-comparison
We target directly this version by using the pattern 5.*.

What would have been great, would be to taste renovate on this branch to make sure this change works out, any guess ? otherwise we commit it to master and see how it goes ! finger crossed !