### PR TITLE
🔧(renovate) ignore python dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,14 @@
       "matchPackageNames": [
         "bootstrap"
       ]
+    },
+    {
+      "enabled": false,
+      "groupName": "ignored python dependencies",
+      "matchManagers": ["setup-cfg"],
+      "matchPackageNames": [
+        "elasticsearch"
+      ]
     }
   ]
 }


### PR DESCRIPTION


## Purpose

Renovate service is trying to update the version of elasticsearch. Ashley can
only work with version 5 of elasticsearch. We create a dedicated package rule
in renovate's config to ignore this specific update.

## Proposal

configure renovate to ignore the update of elasticsearch
