### PR TITLE
🔧(renovate) ignore js dependencies bootstrap

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,15 @@
 {
   "extends": [
     "github>openfun/renovate-configuration"
+  ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "groupName": "ignored js dependencies",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "bootstrap"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Purpose

Renovate service is trying to upgrade the version of bootstrap. Ashley is not
configured yet to properly work with version 5 of bootstrap. There is
different breaking styles that need to be fixed first. We still want
renovate to work for other dependencies, so we explicitly exclude
bootstrap from the config of renovate....


## Proposal

Create a packageRule to avoid the upgrade of bootstrap