### PR TITLE
🗑️(back) filter search on current lti_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - Clean built frontend files before each build
  - Upgrade node to version 14, the current LTS
  - Fix import of the user model in the factory
+ - Filter search results to current LTIContext
 
 ### Added
  

--- a/src/ashley/machina_extensions/forum_search/forms.py
+++ b/src/ashley/machina_extensions/forum_search/forms.py
@@ -3,8 +3,12 @@
     ==================
     This module defines forms provided by the ``forum_search`` application.
 """
-
 from machina.apps.forum_search.forms import SearchForm as MachinaSearchForm
+from machina.core.db.models import get_model
+from machina.core.loading import get_class
+
+Forum = get_model("forum", "Forum")
+PermissionHandler = get_class("forum_permission.handler", "PermissionHandler")
 
 
 class SearchForm(MachinaSearchForm):
@@ -12,6 +16,25 @@ class SearchForm(MachinaSearchForm):
     Override Django Machina's SearchForm to allow searching poster user names
     even with an empty search in the main field.
     """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Init form, code based on base class MachinaSearchForm. A filter on lti_context
+        has been added.
+        """
+        # Loads current lti_context to filter forum search
+        lti_contexts = kwargs.pop("lti_context", None)
+        super().__init__(*args, **kwargs)
+        user = kwargs.pop("user", None)
+        self.allowed_forums = PermissionHandler().get_readable_forums(
+            Forum.objects.filter(lti_contexts=lti_contexts), user
+        )
+        # self.allowed_forums is used in search method of MachinaSearchForm
+        if self.allowed_forums:
+            self.fields["search_forums"].choices = [
+                (f.id, "{} {}".format("-" * f.margin_level, f.name))
+                for f in self.allowed_forums
+            ]
 
     def clean(self):
         """

--- a/src/ashley/machina_extensions/forum_search/views.py
+++ b/src/ashley/machina_extensions/forum_search/views.py
@@ -1,0 +1,25 @@
+"""
+    Forum search views
+    ==================
+
+    This module defines views provided by the ``forum_search`` application.
+
+"""
+from haystack import views
+
+from ashley.context_mixins import get_current_lti_session
+
+
+class FacetedSearchView(views.FacetedSearchView):
+    """View to show search results"""
+
+    template = "forum_search/search.html"
+
+    def build_form(self, form_kwargs=None):
+        form = super().build_form(
+            form_kwargs={
+                "user": self.request.user,
+                "lti_context": get_current_lti_session(self.request),
+            }
+        )
+        return form


### PR DESCRIPTION
## Purpose

A user can be part of multiple forums attached to different classes.
We want the search to keep is current scope and only search in forums
that are related to the course user is actually logged in. Currently,
a user can search in all the forums he has access to and it can be a
bit confusing. Clicking on a result that lead to another course,
connects the user in a different forum from is original search. Results
might not be even relevant as context is different than expected. To be
more relevant and not to loose our users, we filter results to current
LTIContext and only show results from forum of the current class.

## Proposal

Add a filter to only search on forums from this LTIContext to restrict search
