### PR TITLE
🔧(sandbox) allowing multiple forums for a same LTIContext on sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - add frontend internationalisation and react components autoload
  - add django rest framework to promote/revoke moderators for current LTIContext
  - add new role moderator and permission to manage moderators
+ - add a `LTI ID` field in the sandbox settings to be able to have multiple
+   forums for a same LTIContext
 
 ### Fixed
  - fix sorting on sticky and announcements topics

--- a/sandbox/dev_tools/forms.py
+++ b/sandbox/dev_tools/forms.py
@@ -1,5 +1,7 @@
 """Forms definition for the dev_tools application."""
 
+import uuid
+
 from django import forms
 from django.utils.translation import gettext_lazy as _
 from lti_toolbox.models import LTIPassport
@@ -32,6 +34,11 @@ class LTIConsumerForm(forms.Form):
     )
     course_title = forms.CharField(
         label="Course Title", max_length=100, initial="Mathematics 101"
+    )
+
+    forum_lti_id = forms.UUIDField(
+        label="LTI ID",
+        initial=uuid.uuid5(uuid.NAMESPACE_DNS, "default"),
     )
 
     role = forms.ChoiceField(

--- a/sandbox/dev_tools/views.py
+++ b/sandbox/dev_tools/views.py
@@ -28,11 +28,7 @@ def dev_consumer(request: HttpRequest) -> HttpResponse:
             launch_url = request.build_absolute_uri(
                 reverse(
                     "forum.lti.view",
-                    kwargs={
-                        "uuid": uuid.uuid5(
-                            uuid.NAMESPACE_DNS, form.cleaned_data["course_id"]
-                        )
-                    },
+                    kwargs={"uuid": form.cleaned_data["forum_lti_id"]},
                 )
             )
             lti_params = _generate_signed_parameters(form, launch_url, passport)


### PR DESCRIPTION


## Purpose

The sandbox enables to run Ashley in an `iframe`. So far a unique lunch url was set
and its value was defined according to the course id. This was blocking the option
of having multiple forums for the same course using the sandbox. As we are adding
constraints on seeing forums from the same LTIContext, this limit is stopping us from
reproducing cases that we are trying to implement. Adding a lunch URL that can be set
with different values will fix this limit.


## Proposal

Add a field to set up a different lunch URL.
