### PR TITLE
🔖(ashley) bump version to 1.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0-beta.6] - 2021-06-28
+
 ### Changed
 
  - Clean built frontend files before each build
@@ -29,7 +31,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
  - fix sorting on sticky and announcements topics
 
-## [1.0.0-beta.5] - 2020-03-01
+## [1.0.0-beta.5] - 2021-03-01
 
 ### Changed
 
@@ -155,7 +157,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
  - Update sandbox settings to be able to run Ashley in an `iframe` on multiple
    external websites
 
-[Unreleased]: https://github.com/openfun/ashley/compare/v1.0.0-beta.5...master
+[Unreleased]: https://github.com/openfun/ashley/compare/v1.0.0-beta.6...master
+[1.0.0-beta.6]: https://github.com/openfun/ashley/compare/v1.0.0-beta.5...v1.0.0-beta.6
 [1.0.0-beta.5]: https://github.com/openfun/ashley/compare/v1.0.0-beta.4...v1.0.0-beta.5
 [1.0.0-beta.4]: https://github.com/openfun/ashley/compare/v1.0.0-beta.3...v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/openfun/ashley/compare/v1.0.0-beta.2...v1.0.0-beta.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ashley
-version = 1.0.0-beta.5
+version = 1.0.0-beta.6
 description = A self-hosted discussion forum for learning
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ashley",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "A self-hosted discussion forum for learning",
   "scripts": {
     "build": "tsc --noEmit && webpack",


### PR DESCRIPTION
### Changed

 - Clean built frontend files before each build
 - Upgrade node to version 14, the current LTS
 - Fix import of the user model in the factory
 - Filter search results to current LTIContext

### Added

 - add react components to manage moderators for current LTIContext
 - add django rest framework to promote/revoke moderators for current LTIContext
 - add new role moderator and permission to manage moderators
 - allow sorting discussion topics
 - add a `LTI ID` field in the sandbox settings to be able to have multiple
   forums for a same LTIContext
 - autoload for AshleyEditor component and translation to frontend
 - add API endpoint and Amazon S3 to upload image

### Fixed
 - fix sorting on sticky and announcements topics


