### PR TITLE
Fix/s3 storage

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -266,8 +266,8 @@ class Base(Configuration):
     MACHINA_PROFILE_AVATARS_ENABLED = False
     MACHINA_USER_DISPLAY_NAME_METHOD = "get_public_username_with_default"
 
-    MAX_UPLOAD_FILE_MB = 3
-    IMAGE_TYPE_ALLOWED = ["gif", "jpeg", "jpg", "png", "svg"]
+    MAX_UPLOAD_FILE_MB = values.PositiveIntegerValue(5)
+    IMAGE_TYPE_ALLOWED = values.ListValue(["gif", "jpeg", "jpg", "png", "svg"])
 
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -130,6 +130,7 @@ class Base(Configuration):
 
     # AWS
     AWS_ACCESS_KEY_ID = values.SecretValue()
+    AWS_LOCATION = values.Value("media/")
     AWS_S3_CUSTOM_DOMAIN = values.Value()
     AWS_S3_REGION_NAME = values.Value()
     AWS_S3_URL_PROTOCOL = values.Value("https")

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -26,7 +26,7 @@ resource "aws_cloudfront_distribution" "ashley_cloudfront_distribution" {
   }
   # Origin for the media S3 bucket
   origin {
-    domain_name = aws_s3_bucket.ashley_media.bucket_domain_name
+    domain_name = aws_s3_bucket.ashley_media.bucket_regional_domain_name
     origin_id   = local.s3_media_origin_id
 
     s3_origin_config {


### PR DESCRIPTION
## Purpose

This PR addresses some S3 related issues:

- The cloudfront distribution doesn't work : it redirects to S3 instead of serving the actual content.

- The default ashley settings are not compatible with the cloudfront distribution declared with terraform. All uploaded medias should start with the `/media/` prefix.

- We want to be able to customize the `IMAGE_TYPE_ALLOWED` and `MAX_UPLOAD_FILE_MB` settings with environment variables.

## Proposal

- Use S3 regional bucket URL in the cloudfront distribution to avoid redirect issue ( [terraform reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#bucket_regional_domain_name) and [related issue](https://forums.aws.amazon.com/thread.jspa?threadID=216814))
- Add `AWS_LOCATION` setting with a working default value (`media/` prefix)
- Use django configurations to define `IMAGE_TYPE_ALLOWED` and `MAX_UPLOAD_FILE_MB`  settings
