### PR TITLE
🐛(back) limit the scope of the unread topics view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- limit the scope of the unread topics view to the current LTIContext
+
 ## [1.0.0-beta.6] - 2021-06-28
 
 ### Changed

--- a/tests/ashley/machina_extensions/forum_permission/test_permission_handler.py
+++ b/tests/ashley/machina_extensions/forum_permission/test_permission_handler.py
@@ -1,8 +1,13 @@
 from django.test import TestCase
 from machina.apps.forum_permission.shortcuts import assign_perm
+from machina.core.db.models import get_model
+from machina.core.loading import get_class
 
 from ashley import SESSION_LTI_CONTEXT_ID
 from ashley.factories import ForumFactory, LTIContextFactory, UserFactory
+
+PermissionHandler = get_class("forum_permission.handler", "PermissionHandler")
+Forum = get_model("forum", "Forum")
 
 
 class PermissionHandlerTestCase(TestCase):
@@ -66,3 +71,59 @@ class PermissionHandlerTestCase(TestCase):
         self.assertNotContains(response, "Forum A2")
         self.assertContains(response, "Forum B1")
         self.assertNotContains(response, "Forum B2")
+
+    def test_get_readable_forums(self):
+        """
+        The get_readable_forums() function should filter the results according
+        to the LTIContext of the user, if available.
+        """
+        user = UserFactory()
+        lti_context_a = LTIContextFactory(lti_consumer=user.lti_consumer)
+        lti_context_b = LTIContextFactory(lti_consumer=user.lti_consumer)
+
+        # Create 2 forums for context A
+        forum_a1 = ForumFactory(name="Forum A1")
+        forum_a1.lti_contexts.add(lti_context_a)
+        forum_a2 = ForumFactory(name="Forum A2")
+        forum_a2.lti_contexts.add(lti_context_a)
+        # Create 2 forums for context B
+        forum_b1 = ForumFactory(name="Forum B1")
+        forum_b1.lti_contexts.add(lti_context_b)
+        forum_b2 = ForumFactory(name="Forum B2")
+        forum_b2.lti_contexts.add(lti_context_b)
+
+        # Grant read-only access for forums A1, A2 and B1 to our user
+        assign_perm("can_see_forum", user, forum_a1, True)
+        assign_perm("can_read_forum", user, forum_a1, True)
+        assign_perm("can_see_forum", user, forum_a2, True)
+        assign_perm("can_read_forum", user, forum_a2, True)
+        assign_perm("can_see_forum", user, forum_b1, True)
+        assign_perm("can_read_forum", user, forum_b1, True)
+
+        # Instantiate the permission Handler
+        permission_handler = PermissionHandler()
+
+        # When the permission handler has no lti context specified,
+        # the get_readable_forums should return all forums the user
+        # has access to
+        forums_qs = Forum.objects.all()
+        forums_list = list(Forum.objects.all())
+        readable_forums = permission_handler.get_readable_forums(forums_qs, user)
+        self.assertCountEqual(readable_forums, [forum_a1, forum_a2, forum_b1])
+
+        # Inject a LTI context into the permission handler and ensure that
+        # the results are filtered according to it
+        permission_handler.current_lti_context_id = lti_context_a.id
+        readable_forums = permission_handler.get_readable_forums(forums_qs, user)
+        self.assertCountEqual(readable_forums, [forum_a1, forum_a2])
+
+        # Check the same with a list of forums instead of a QuerySet
+        readable_forums = permission_handler.get_readable_forums(forums_list, user)
+        self.assertCountEqual(readable_forums, [forum_a1, forum_a2])
+
+        # Inject another LTIContext into the permission handler
+        permission_handler.current_lti_context_id = lti_context_b.id
+        readable_forums = permission_handler.get_readable_forums(forums_qs, user)
+        self.assertCountEqual(readable_forums, [forum_b1])
+        readable_forums = permission_handler.get_readable_forums(forums_list, user)
+        self.assertCountEqual(readable_forums, [forum_b1])


### PR DESCRIPTION
## Purpose

When a user displays the list of its unread topics, the list contains
topics belonging to every forums the user has access to. They should
be limited to forums related to the LTIContext the user is coming
from.

## Proposal

- [x] Update the query in machina's permission handler function `get_readable_forums`