### PR TITLE
✨(xapi) track topic views with XAPI events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic 
+and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - allow to search users by any of its meaningful fields in Django admin
 - allow to archive a forum with the new `can_archive_forum` permission
+- track topic views with XAPI events
 
 ## [1.0.0] - 2021-08-16
 
@@ -23,48 +24,49 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
- - Clean built frontend files before each build
- - Upgrade node to version 14, the current LTS
- - Fix import of the user model in the factory
- - Filter search results to current LTIContext
+- Clean built frontend files before each build
+- Upgrade node to version 14, the current LTS
+- Fix import of the user model in the factory
+- Filter search results to current LTIContext
 
 ### Added
- 
- - add react components to manage moderators for current LTIContext
- - add django rest framework to promote/revoke moderators for current LTIContext
- - add new role moderator and permission to manage moderators
- - allow sorting discussion topics
- - add a `LTI ID` field in the sandbox settings to be able to have multiple
-   forums for a same LTIContext
- - autoload for AshleyEditor component and translation to frontend
- - add API endpoint and Amazon S3 to upload image
+
+- add react components to manage moderators for current LTIContext
+- add django rest framework to promote/revoke moderators for current LTIContext
+- add new role moderator and permission to manage moderators
+- allow sorting discussion topics
+- add a `LTI ID` field in the sandbox settings to be able to have multiple
+  forums for a same LTIContext
+- autoload for AshleyEditor component and translation to frontend
+- add API endpoint and Amazon S3 to upload image
 
 ### Fixed
- - fix sorting on sticky and announcements topics
+
+- fix sorting on sticky and announcements topics
 
 ## [1.0.0-beta.5] - 2021-03-01
 
 ### Changed
 
- - upgrade django-machina from 1.1.3 to 1.1.4
- - add button to insert quotes in the draftjs editor
- - limit forum listing to the current user LTIContext id
- - add code blocks in the editor and auto-highlight code in the forum
- - create a forum for each LTIContext id
- - add index to the Forum model
+- upgrade django-machina from 1.1.3 to 1.1.4
+- add button to insert quotes in the draftjs editor
+- limit forum listing to the current user LTIContext id
+- add code blocks in the editor and auto-highlight code in the forum
+- create a forum for each LTIContext id
+- add index to the Forum model
 
 ### Fixed
 
- - fix serialization error in search index update
- - remove deprecated url in favor of re_path
- - prevent inactive users from authenticating via LTI
- - prevent linking a User to a LTIContext related to different LTI Consumer
+- fix serialization error in search index update
+- remove deprecated url in favor of re_path
+- prevent inactive users from authenticating via LTI
+- prevent linking a User to a LTIContext related to different LTI Consumer
 
 ### Added
 
- - add frontend test for draft-js editor
- - add a ribbon icon when an instructor is the writer of a post or a topic
- - add feature in AshleyEditor to mention any active user in the current topic
+- add frontend test for draft-js editor
+- add a ribbon icon when an instructor is the writer of a post or a topic
+- add feature in AshleyEditor to mention any active user in the current topic
 
 ## [1.0.0-beta.4] - 2020-12-22
 
@@ -86,89 +88,89 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
- - add permission `can_rename_forum`
- - add form to edit the forum name
- - add management command `sync_group_permissions`
+- add permission `can_rename_forum`
+- add form to edit the forum name
+- add management command `sync_group_permissions`
 
 ### Changed
 
- - upgrade django-machina to 1.1.3
- - upgrade django-haystack to 3.0
- - upgrade django from 3.0 to 3.1
- - replace `lti_provider` app with `django-lti-toolbox`
- - update translations
- - activate search functionality
- - update search form template
+- upgrade django-machina to 1.1.3
+- upgrade django-haystack to 3.0
+- upgrade django from 3.0 to 3.1
+- replace `lti_provider` app with `django-lti-toolbox`
+- update translations
+- activate search functionality
+- update search form template
 
 ### Fixed
 
- - fix signature max length errors caused by the draft.js markup
- - fix Draft.js editor resize issue with static toolbar
+- fix signature max length errors caused by the draft.js markup
+- fix Draft.js editor resize issue with static toolbar
 
 ## Removed
 
- - remove `SameSiteNoneMiddleware`
+- remove `SameSiteNoneMiddleware`
 
 ## [1.0.0-beta.2] - 2020-05-18
 
 ### Added
 
- - add dependency to bootstrap 4.4.1 and font-awesome 5.13.0
- - add button to insert a link in AshleyEditor component
+- add dependency to bootstrap 4.4.1 and font-awesome 5.13.0
+- add button to insert a link in AshleyEditor component
 
 ### Changed
 
- - build the forum CSS theme inside ashley instead of using the compiled CSS
-   file distributed with django-machina
- - coalesce SASS color variables between django-machina and bootstrap
- - use a fluid container for a better iframe integration
- - change SASS colors
+- build the forum CSS theme inside ashley instead of using the compiled CSS
+  file distributed with django-machina
+- coalesce SASS color variables between django-machina and bootstrap
+- use a fluid container for a better iframe integration
+- change SASS colors
 
 ## [1.0.0-beta.1] - 2020-05-04
 
 ### Added
 
- - render emoji with emojione on forum posts
- - add support for Moodle in ashley's LTI authentication backend
- - add SameSiteNoneMiddleware to force SameSite=None on CSRF and session cookies
- 
+- render emoji with emojione on forum posts
+- add support for Moodle in ashley's LTI authentication backend
+- add SameSiteNoneMiddleware to force SameSite=None on CSRF and session cookies
+
 ### Changed
 
- - update draftjs link decorator to open links in new tab and to add attribute
-   `rel="nofollow noopener noreferrer"`
- - refactor `<AshleyEditor />` in functional component using hooks
- - improve focus management on `<AshleyEditor />`
+- update draftjs link decorator to open links in new tab and to add attribute
+  `rel="nofollow noopener noreferrer"`
+- refactor `<AshleyEditor />` in functional component using hooks
+- improve focus management on `<AshleyEditor />`
 
 ### Fixed
 
-  - heading buttons rendering in ashley editor on Firefox
+- heading buttons rendering in ashley editor on Firefox
 
 ## [1.0.0-beta.0] - 2020-04-16
 
 ### Added
 
- - lti_provider django application
- - install `django-machina` forum in the `sandbox` project
- - custom user model, auth backend and LTI handlers in `ashley`
- - standalone LTI consumer to test ashley in development
- - permission management and group synchronization based on LTI roles
- - `asley.machina_extensions.forum` application to extend django-machina's
-   forum model.
- - automatic forum creation based on the context of the LTI launch request
- - Instructor and Administrator LTI roles have special permissions on their
-   forum.
- - customize django-machina to have a basic set of forum features
- - i18n support and translations with crowdin
- - add basic CSS file in ashley to override machina's stylesheet
- - each forum has its own unique LTI launch URL
- - wysiwyg editor based on Draft.js
- 
+- lti_provider django application
+- install `django-machina` forum in the `sandbox` project
+- custom user model, auth backend and LTI handlers in `ashley`
+- standalone LTI consumer to test ashley in development
+- permission management and group synchronization based on LTI roles
+- `asley.machina_extensions.forum` application to extend django-machina's
+  forum model.
+- automatic forum creation based on the context of the LTI launch request
+- Instructor and Administrator LTI roles have special permissions on their
+  forum.
+- customize django-machina to have a basic set of forum features
+- i18n support and translations with crowdin
+- add basic CSS file in ashley to override machina's stylesheet
+- each forum has its own unique LTI launch URL
+- wysiwyg editor based on Draft.js
+
 ### Changed
 
- - Update sandbox settings to be able to run Ashley in an `iframe` on multiple
-   external websites
+- Update sandbox settings to be able to run Ashley in an `iframe` on multiple
+  external websites
 
-[Unreleased]: https://github.com/openfun/ashley/compare/v1.0.0...master
+[unreleased]: https://github.com/openfun/ashley/compare/v1.0.0...master
 [1.0.0]: https://github.com/openfun/ashley/compare/v1.0.0-beta.6...v1.0.0
 [1.0.0-beta.6]: https://github.com/openfun/ashley/compare/v1.0.0-beta.5...v1.0.0-beta.6
 [1.0.0-beta.5]: https://github.com/openfun/ashley/compare/v1.0.0-beta.4...v1.0.0-beta.5

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -317,14 +317,23 @@ class Development(Base):
             "verbose": {
                 "format": "[%(levelname)s] [%(asctime)s] [%(module)s] "
                 "%(process)d %(thread)d %(message)s"
-            }
+            },
+            "gelf": {
+                "()": "logging_gelf.formatters.GELFFormatter",
+                "null_character": True,
+            },
         },
         "handlers": {
             "console": {
                 "level": "DEBUG",
                 "class": "logging.StreamHandler",
                 "formatter": "verbose",
-            }
+            },
+            "gelf": {
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+                "formatter": "gelf",
+            },
         },
         "loggers": {
             "oauthlib": {"handlers": ["console"], "level": "DEBUG", "propagate": True},
@@ -335,6 +344,9 @@ class Development(Base):
                 "propagate": True,
             },
             "django": {"handlers": ["console"], "level": "INFO", "propagate": True},
+            # This formatter is here as an example to what is possible to do
+            # with xapi loggers.
+            "xapi": {"handlers": ["gelf"], "level": "INFO", "propagate": True},
         },
     }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,9 @@ install_requires =
     draftjs_exporter==4.1.2
     djangorestframework==3.12.4
     elasticsearch>=5.0.0,<6.0.0 # pyup: >=5.0.0,<6.0.0
+    logging-ldp==0.0.6
     oauthlib>=3.0.0
+    tincan==1.0.0
 package_dir =
     =src
 packages = find:

--- a/src/ashley/apps.py
+++ b/src/ashley/apps.py
@@ -6,3 +6,8 @@ class AshleyConfig(AppConfig):
     """Configuration class for the ashley app."""
 
     name = "ashley"
+
+    def ready(self):
+        """ Executes whatever is necessary when the application is ready. """
+        # pylint: disable=import-outside-toplevel,unused-import
+        from . import receivers  # noqa: F401

--- a/src/ashley/receivers.py
+++ b/src/ashley/receivers.py
@@ -1,0 +1,105 @@
+"""This module defines signal receivers for the Ashley application"""
+
+import logging
+
+from django.conf import settings
+from django.dispatch import receiver
+from django.utils.translation import to_locale
+from machina.apps.forum_conversation.signals import topic_viewed
+from machina.conf import settings as machina_settings
+from machina.core.db.models import get_model
+from tincan import (
+    Activity,
+    ActivityDefinition,
+    Context,
+    ContextActivities,
+    LanguageMap,
+    Verb,
+)
+
+from .xapi import build_statement
+
+LTIContext = get_model("ashley", "LTIContext")
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(topic_viewed)
+# pylint: disable=unused-argument
+def track_topic_view(sender, topic, user, request, response, **kwargs):
+    """ Log a XAPI statement when a user views a topic. """
+
+    consumer = getattr(user, "lti_consumer", None)
+    if consumer is None:
+        logger.warning("Unable to get LTI consumer of user %s", user)
+        return
+    xapi_logger = logging.getLogger(f"xapi.{user.lti_consumer.slug}")
+
+    verb = Verb(
+        id="http://id.tincanapi.com/verb/viewed",
+        display=LanguageMap({"en-US": "viewed"}),
+    )
+
+    obj = Activity(
+        id=f"id://ashley/topic/{topic.pk}",
+        definition=ActivityDefinition(
+            name=LanguageMap(
+                {to_locale(settings.LANGUAGE_CODE).replace("_", "-"): topic.subject}
+            ),
+            type="http://id.tincanapi.com/activitytype/discussion",
+            extensions={
+                "https://w3id.org/xapi/acrossx/extensions/total-items": topic.posts_count,
+                "https://w3id.org/xapi/acrossx/extensions/total-pages": (
+                    (topic.posts_count - 1)
+                    // machina_settings.TOPIC_POSTS_NUMBER_PER_PAGE
+                )
+                + 1,
+            },
+        ),
+    )
+
+    parent_activities = [
+        Activity(
+            id=f"uuid://{topic.forum.lti_id}",
+            definition=ActivityDefinition(
+                name=LanguageMap(
+                    {
+                        to_locale(settings.LANGUAGE_CODE).replace(
+                            "_", "-"
+                        ): topic.forum.name
+                    }
+                ),
+                type="http://id.tincanapi.com/activitytype/community-site",
+            ),
+        )
+    ]
+
+    if request.forum_permission_handler.current_lti_context_id is not None:
+        try:
+            lti_context = LTIContext.objects.get(
+                pk=request.forum_permission_handler.current_lti_context_id
+            )
+            parent_activities.append(
+                Activity(
+                    id=lti_context.lti_id,
+                    definition=ActivityDefinition(
+                        type="http://adlnet.gov/expapi/activities/course"
+                    ),
+                )
+            )
+
+        except LTIContext.DoesNotExist:
+            pass
+
+    context = Context(
+        context_activities=ContextActivities(parent=parent_activities),
+        extensions={
+            "http://www.risc-inc.com/annotator/extensions/page": int(
+                request.GET.get("page", default=1)
+            )
+        },
+    )
+
+    statement = build_statement(user, verb, obj, context)
+    if statement:
+        xapi_logger.info(statement.to_json())

--- a/src/ashley/xapi.py
+++ b/src/ashley/xapi.py
@@ -1,0 +1,47 @@
+"""XAPI module."""
+import logging
+import uuid
+from typing import Optional
+
+from django.utils import timezone
+from tincan import Activity, Agent, AgentAccount, Context, Statement, Verb
+
+from ashley.models import AbstractUser
+
+logger = logging.getLogger(__name__)
+
+
+def build_statement(
+    user: AbstractUser,
+    verb: Verb,
+    obj: Activity,
+    context: Context,
+    statement_id: Optional[uuid.UUID] = None,
+) -> Optional[Statement]:
+    """Build a XAPI Statement based on the current context"""
+    timestamp = timezone.now().isoformat()
+    actor = _get_actor_from_user(user)
+    if statement_id is None:
+        statement_id = uuid.uuid4()
+    if actor is None:
+        logger.warning("Unable to get an XAPI actor definition for user %s", user.id)
+        return None
+    return Statement(
+        actor=actor,
+        context=context,
+        id=statement_id,
+        object=obj,
+        timestamp=timestamp,
+        verb=verb,
+    )
+
+
+def _get_actor_from_user(user: AbstractUser) -> Optional[Agent]:
+    """Generate a XAPI Agent object from a Ashley User object"""
+    if user.lti_remote_user_id and user.lti_consumer.url:
+        return Agent(
+            account=AgentAccount(
+                name=user.lti_remote_user_id, home_page=user.lti_consumer.url
+            )
+        )
+    return None

--- a/tests/ashley/test_receivers.py
+++ b/tests/ashley/test_receivers.py
@@ -1,0 +1,134 @@
+"""Test suite for ashley receivers"""
+import json
+
+from django.test import TestCase
+from django.urls import reverse
+from machina.apps.forum_permission.shortcuts import assign_perm
+
+from ashley import SESSION_LTI_CONTEXT_ID
+from ashley.factories import LTIContextFactory, PostFactory, TopicFactory, UserFactory
+
+
+class TestTrackTopicView(TestCase):
+    """Test the track_topic_view receiver"""
+
+    def test_xapi_logger(self):
+        """
+        When a topic is viewed, the test_track_topic receiver should emit an
+        XAPI event on the logger configured for the corresponding LTIConsumer.
+        """
+
+        # Create a topic in a new forum
+        topic = TopicFactory()
+        for _ in range(42):
+            PostFactory(topic=topic)
+
+        # Create a user with access to this forum
+        user = UserFactory()
+        lti_context = LTIContextFactory(
+            lti_consumer=user.lti_consumer,
+            lti_id="course-v1:myschool+mathematics101+session01",
+        )
+        forum = topic.forum
+        forum.lti_contexts.add(lti_context)
+        assign_perm("can_read_forum", user, forum, True)
+
+        topic_url = reverse(
+            "forum_conversation:topic",
+            kwargs={
+                "forum_slug": topic.forum.slug,
+                "forum_pk": topic.forum.pk,
+                "slug": topic.slug,
+                "pk": topic.pk,
+            },
+        )
+
+        logger_name = f"xapi.{user.lti_consumer.slug}"
+        with self.assertLogs(logger=logger_name, level="INFO") as cm:
+            self.client.force_login(user, "ashley.auth.backend.LTIBackend")
+            session = self.client.session
+            session[SESSION_LTI_CONTEXT_ID] = lti_context.id
+            session.save()
+            response = self.client.get(topic_url, data={"page": 2})
+
+            self.assertEqual(response.status_code, 200)
+
+            # One line of debug should have been written
+            self.assertEqual(len(cm.output), 1)
+
+            # Extract XAPI statement from log output
+            log_prefix_len = len(f"{logger_name}:INFO:")
+            raw_xapi_event = cm.output[0][log_prefix_len:]
+            xapi_event = json.loads(raw_xapi_event)
+
+            # The XAPI event should have an ID
+            self.assertIn("id", xapi_event)
+
+            # Validate the actor part of the XAPI event
+            self.assertEqual("Agent", xapi_event["actor"]["objectType"])
+            self.assertEqual(
+                user.lti_consumer.url, xapi_event["actor"]["account"]["homePage"]
+            )
+            self.assertEqual(
+                user.public_username, xapi_event["actor"]["account"]["name"]
+            )
+
+            # Validate the verb
+            self.assertEqual(
+                "http://id.tincanapi.com/verb/viewed", xapi_event["verb"]["id"]
+            )
+
+            # Validate the activity
+            self.assertEqual(
+                f"id://ashley/topic/{topic.pk}", xapi_event["object"]["id"]
+            )
+            self.assertEqual("Activity", xapi_event["object"]["objectType"])
+            self.assertEqual(
+                "http://id.tincanapi.com/activitytype/discussion",
+                xapi_event["object"]["definition"]["type"],
+            )
+
+            # validate the activity definition extensions
+            expected_extensions = {
+                "https://w3id.org/xapi/acrossx/extensions/total-items": 42,
+                "https://w3id.org/xapi/acrossx/extensions/total-pages": 3,
+            }
+
+            self.assertEqual(
+                xapi_event["object"]["definition"]["extensions"], expected_extensions
+            )
+
+            # Validate the context
+            self.assertEqual(
+                f"uuid://{topic.forum.lti_id}",
+                xapi_event["context"]["contextActivities"]["parent"][0]["id"],
+            )
+            self.assertEqual(
+                "Activity",
+                xapi_event["context"]["contextActivities"]["parent"][0]["objectType"],
+            )
+            self.assertEqual(
+                xapi_event["context"]["extensions"],
+                {"http://www.risc-inc.com/annotator/extensions/page": 2},
+            )
+            self.assertEqual(
+                "http://id.tincanapi.com/activitytype/community-site",
+                xapi_event["context"]["contextActivities"]["parent"][0]["definition"][
+                    "type"
+                ],
+            )
+
+            self.assertEqual(
+                "course-v1:myschool+mathematics101+session01",
+                xapi_event["context"]["contextActivities"]["parent"][1]["id"],
+            )
+            self.assertEqual(
+                "Activity",
+                xapi_event["context"]["contextActivities"]["parent"][1]["objectType"],
+            )
+            self.assertEqual(
+                "http://adlnet.gov/expapi/activities/course",
+                xapi_event["context"]["contextActivities"]["parent"][1]["definition"][
+                    "type"
+                ],
+            )

--- a/tests/ashley/test_xapi.py
+++ b/tests/ashley/test_xapi.py
@@ -1,0 +1,75 @@
+"""Test suite for Ashley's xapi module"""
+import uuid
+
+from django.test import TestCase
+from tincan import (
+    Activity,
+    ActivityDefinition,
+    Context,
+    ContextActivities,
+    LanguageMap,
+    Verb,
+)
+
+from ashley.factories import UserFactory
+from ashley.xapi import build_statement
+
+
+class TestXAPI(TestCase):
+    """Test utility functions provided by the xapi module"""
+
+    def test_build_statement(self):
+        """
+        The build_statement function should return a valid tincan
+        Statement.
+        """
+        user = UserFactory()
+
+        verb = Verb(
+            id="https://activitystrea.ms/schema/1.0/create",
+            display=LanguageMap({"en-US": "created"}),
+        )
+        activity = Activity(
+            id=f"id://ashley/topic/{uuid.uuid4()}",
+            definition=ActivityDefinition(
+                name=LanguageMap({"en-US": "test topic"}),
+                type="http://id.tincanapi.com/activitytype/discussion",
+            ),
+        )
+        context = Context(
+            context_activities=ContextActivities(
+                parent=[
+                    Activity(
+                        id=f"uuid://{uuid.uuid4()}",
+                        definition=ActivityDefinition(
+                            name=LanguageMap({"en-US": "test forum"}),
+                            type="http://id.tincanapi.com/activitytype/community-site",
+                        ),
+                    )
+                ]
+            )
+        )
+
+        statement1 = build_statement(user, verb, activity, context)
+        statement2 = build_statement(user, verb, activity, context)
+
+        # The function should generate a random, non empty uuid as a
+        # statement ID
+        self.assertIsInstance(statement1.id, uuid.UUID)
+        self.assertIsInstance(statement2.id, uuid.UUID)
+        self.assertNotEqual(statement1.id, statement2.id)
+
+        # The statement id can also be specified
+        statement3_id = uuid.uuid4()
+        statement3 = build_statement(user, verb, activity, context, statement3_id)
+        self.assertEqual(statement3_id, statement3.id)
+
+        # The verb, object and context should correspond to the given arguments
+        self.assertEqual(statement1.verb, verb)
+        self.assertEqual(statement1.object, activity)
+        self.assertEqual(statement1.context, context)
+
+        # The Actor part of the statement should reflect the user passed as an
+        # argument
+        self.assertEqual(statement1.actor.account.name, user.lti_remote_user_id)
+        self.assertEqual(statement1.actor.account.home_page, user.lti_consumer.url)


### PR DESCRIPTION
## Purpose

We want to track our users' actions using the XAPI standard and
collect these events for analysis.

## Proposal

- [x] add `xapi` utility module to help building XAPI statements, using tincan library
- [x] track "topic view" event using Django signals
- [x] Add gelf logger in the sandbox settings as an example

