### PR TITLE
✨(admin) allow to search users by username in django admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- allow to search users by any of its meaningful fields in Django admin
+
 ## [1.0.0] - 2021-08-16
 
 ### Fixed

--- a/src/ashley/admin.py
+++ b/src/ashley/admin.py
@@ -7,3 +7,12 @@ from .models import User
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
     """Admin class for Ashley's User model."""
+
+    search_fields = (
+        "username",
+        "first_name",
+        "last_name",
+        "email",
+        "public_username",
+        "lti_remote_user_id",
+    )


### PR DESCRIPTION
## Purpose

We want to be able to search users by username in django admin. In its
current state, the User admin view is unusable with thousands of
users.

## Proposal

- [x] Add the `username` field to the search fields in the UserAdmin
