### PR TITLE
🔖(ashley) bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0] - 2021-10-28
+
 ### Added
 
 - track forum views, topic and post updates and creations with xAPI events
@@ -175,7 +177,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Update sandbox settings to be able to run Ashley in an `iframe` on multiple
   external websites
 
-[unreleased]: https://github.com/openfun/ashley/compare/v1.0.0...master
+[unreleased]: https://github.com/openfun/ashley/compare/v1.1.0...master
+[1.1.0]: https://github.com/openfun/ashley/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/openfun/ashley/compare/v1.0.0-beta.6...v1.0.0
 [1.0.0-beta.6]: https://github.com/openfun/ashley/compare/v1.0.0-beta.5...v1.0.0-beta.6
 [1.0.0-beta.5]: https://github.com/openfun/ashley/compare/v1.0.0-beta.4...v1.0.0-beta.5

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,6 +15,8 @@ They will be documented in this file:
 
 ### Unreleased
 
+### Ashley 1.1.0
+
 Two new permissions have been added in this release : `can_archive_forum`, 
 `can_move_topics`.
 By default, these permissions will only be added to new users with administrator or

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ashley
-version = 1.0.0
+version = 1.1.0
 description = A self-hosted discussion forum for learning
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ashley",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A self-hosted discussion forum for learning",
   "scripts": {
     "build": "tsc --noEmit && webpack",


### PR DESCRIPTION
### Added

- allow to search users by any of its meaningful fields in Django admin
- allow to archive a forum with the new `can_archive_forum` permission
- track topic views with XAPI events
- automatically assign a public_username to instructors and administrators when none is defined in the LTI authentication
- allow  administrators and instructors to move topics to forums in the same LTIContext
- track forum views, topic and post updates and creations with xAPI events
