### PR TITLE
🐛(back) exclude archived forums from select forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- exclude archived forums from the list of forums to move topics to
+
 ## [1.1.0] - 2021-10-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - exclude archived forums from the list of forums to move topics to
+- exclude archived forums from the list of forums of advanced search
 
 ## [1.1.0] - 2021-10-28
 

--- a/src/ashley/machina_extensions/forum_permission/handler.py
+++ b/src/ashley/machina_extensions/forum_permission/handler.py
@@ -86,7 +86,9 @@ class PermissionHandler(BasePermissionHandler):
         if not hasattr(self, "_all_forums"):
             if self.current_lti_context_id:
                 self._all_forums = list(
-                    Forum.objects.filter(lti_contexts__id=self.current_lti_context_id)
+                    Forum.objects.filter(
+                        archived=False, lti_contexts__id=self.current_lti_context_id
+                    )
                 )
             else:
                 super()._get_all_forums()

--- a/src/ashley/machina_extensions/forum_search/forms.py
+++ b/src/ashley/machina_extensions/forum_search/forms.py
@@ -27,7 +27,7 @@ class SearchForm(MachinaSearchForm):
         super().__init__(*args, **kwargs)
         user = kwargs.pop("user", None)
         self.allowed_forums = PermissionHandler().get_readable_forums(
-            Forum.objects.filter(lti_contexts=lti_contexts), user
+            Forum.objects.filter(archived=False, lti_contexts=lti_contexts), user
         )
         # self.allowed_forums is used in search method of MachinaSearchForm
         if self.allowed_forums:

--- a/tests/ashley/machina_extensions/forum_moderation/test_forum_moderation.py
+++ b/tests/ashley/machina_extensions/forum_moderation/test_forum_moderation.py
@@ -266,7 +266,7 @@ class ForumModerationTestViewForm(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        
+
         # Control that we get an error and the move is not executed
         self.assertContains(
             response,


### PR DESCRIPTION

## Purpose

If a forum gets archived, we shouldn't be able to move topics to
this forum. Lists must ignore archived forums. In the same way, if
we want to use the advanced search, we shouldn't be able to search
in a forum that has been archived.


## Proposal

Exclude archived forums from the two listing
