### PR TITLE
✨(forum) use the name of a previous forum with the same `lti_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- use the name of a previous forum with the same `lti_id`
 
 ## [1.1.1] - 2021-11-03
 


### PR DESCRIPTION

## Purpose

When duplicating courses from an LMS, forums get copied. By default,
each forum has a name set with the value of the course's name. It's
more likely, when a course gets copied, that instructors want to keep
the same forum's names. To simplify this use case, we define the
default name of each forum with an existing UUID to the previous name
defined for the other `context.id`.


## Proposal

When creating a forum, we search if this lti_id already exists to reuse the name.
