### PR TITLE
✨(front) add an icon for administrator on topic and post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - use the name of a previous forum with the same `lti_id`
 - allow sorting forums on the home page
+- add a ribbon icon when an administrator is the writer of a post or a topic
 
 ## [1.1.1] - 2021-11-03
 

--- a/sandbox/dev_tools/forms.py
+++ b/sandbox/dev_tools/forms.py
@@ -45,6 +45,7 @@ class LTIConsumerForm(forms.Form):
         choices=(
             ("Student", _("Student")),
             ("Instructor", _("Instructor")),
+            ("Administrator", _("Administrator")),
         )
     )
 

--- a/src/ashley/templates/partials/user_icon.html
+++ b/src/ashley/templates/partials/user_icon.html
@@ -6,4 +6,9 @@
     <span class="sr-only">{%trans 'Instructor'%}</span>
     </i>
 {% endif %}
+{% if topic|is_user_administrator:user %}
+    <i class="icon_writer fas fa-award" aria-hidden="true" title="{%trans 'Administrator'%}">
+    <span class="sr-only">{%trans 'Administrator'%}</span>
+    </i>
+{% endif %}
 {% endspaceless %}

--- a/src/ashley/templatetags/custom_tags.py
+++ b/src/ashley/templatetags/custom_tags.py
@@ -3,7 +3,7 @@ from django import template
 from machina.core.db.models import get_model
 from machina.templatetags.forum_tags import forum_list
 
-from ashley.defaults import _FORUM_ROLE_INSTRUCTOR
+from ashley.defaults import _FORUM_ROLE_ADMINISTRATOR, _FORUM_ROLE_INSTRUCTOR
 
 LTIContext = get_model("ashley", "LTIContext")
 
@@ -23,6 +23,23 @@ def is_user_instructor(topic, user):
     # as instructor for this forum
     return any(
         _FORUM_ROLE_INSTRUCTOR in lti.get_user_roles(user)
+        for lti in LTIContext.objects.filter(forum=topic.forum)
+    )
+
+
+@register.filter()
+def is_user_administrator(topic, user):
+    """
+    This will return a boolean indicating if the passed user is admin
+    for the given topic.
+    Usage::
+        {% if topic|is_user_administrator:user %}...{% endif %}
+    """
+    # get the list of lti concerns by this forum, one forum can have multiple LTI Context
+    # if the user is admin in one of them then he is considered
+    # as admin for this forum
+    return any(
+        _FORUM_ROLE_ADMINISTRATOR in lti.get_user_roles(user)
         for lti in LTIContext.objects.filter(forum=topic.forum)
     )
 

--- a/tests/ashley/test_templatetags_custom_tags.py
+++ b/tests/ashley/test_templatetags_custom_tags.py
@@ -65,7 +65,7 @@ class TestIsUserInstructorTag(TestCase):
         Given two users. User1 is student of the forum, User2 is instructor.
         We control that is_user_instructor can detect if a user is an instructor.
         Then a forum can be part of multiple contexts. If a user is instructor in one context,
-        he is considered admin of this forum in all contexts. We add a new context to the forum
+        he is considered intructor of this forum in all contexts. We add a new context to the forum
         where user is instructor and test that user is now considered as instructor
         """
         # load template
@@ -278,6 +278,234 @@ class TestIsUserInstructorTag(TestCase):
             (
                 '<i class="icon_writer fas fa-award" aria-hidden="true" title="Instructor">'
                 '<span class="sr-only">Instructor</span>'
+                "</i>"
+            )
+            in html_second_post
+        )
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user1.id}/">Val&#233;ry</a>')
+            in html_second_post
+        )
+
+    @staticmethod
+    def test_can_tell_if_the_user_is_administrator_of_this_forum():
+        """
+        Given two users. User1 is student of the forum, User2 is administrator.
+        We control that is_user_administrator can detect if a user is an administrator.
+        Then a forum can be part of multiple contexts. If a user is administrator in one context,
+        he is considered intructor of this forum in all contexts. We add a new context to the forum
+        where user is administrator and test that user is now considered as administrator
+        """
+        # load template
+        def get_rendered(topic, user):
+            template = Template(
+                "{% load custom_tags %}"
+                + "{% if topic|is_user_administrator:user %}YES{% else %}NO{% endif %}"
+            )
+            context = Context({"topic": topic, "user": user})
+            rendered = template.render(context)
+
+            return rendered
+
+        lti_consumer = LTIConsumerFactory()
+        # Create two LTI Context
+        context1 = LTIContextFactory(lti_consumer=lti_consumer)
+        context2 = LTIContextFactory(lti_consumer=lti_consumer)
+        # Create two users
+        user1 = UserFactory(lti_consumer=lti_consumer)
+        user2 = UserFactory(lti_consumer=lti_consumer)
+
+        # Sync user1 groups in context1 with role "student"
+        context1.sync_user_groups(user1, ["student"])
+        # Sync user1 groups in context2 with role "administrator"
+        context2.sync_user_groups(user1, ["administrator"])
+        # Sync user2 groups in context1 with role "administrator"
+        context1.sync_user_groups(user2, ["administrator"])
+
+        # Create forum and add context1
+        forum = ForumFactory(name="Initial forum name")
+        forum.lti_contexts.add(context1)
+
+        # Set up topic
+        topic = TopicFactory(forum=forum, poster=user1, subject="topic création")
+
+        # Chek that user1 is not administrator
+        assert get_rendered(topic, user1) == "NO"
+        # Chek that user2 is administrator
+        assert get_rendered(topic, user2) == "YES"
+
+        # Add forum to context2 where user1 has role "administrator"
+        forum.lti_contexts.add(context2)
+        # Check that user1 is now administrator as well
+        assert get_rendered(topic, user1) == "YES"
+
+    def test_render_block_is_admin_of_this_forum(self):
+        """
+        check that the admin icon is present on the different views
+        as expected
+        """
+        lti_consumer = LTIConsumerFactory()
+        # Create two users
+        user1 = UserFactory(public_username="Valéry", lti_consumer=lti_consumer)
+        user2 = UserFactory(public_username="François", lti_consumer=lti_consumer)
+        # Create an LTI Context
+        context = LTIContextFactory(lti_consumer=lti_consumer)
+        # Sync user1 groups in context with role "administrator"
+        context.sync_user_groups(user1, ["administrator"])
+        # Sync user1 groups in context with role "student"
+        context.sync_user_groups(user2, ["student"])
+
+        # Create forum and add context
+        forum = ForumFactory(name="forum_test")
+        forum.lti_contexts.add(context)
+
+        # assign permission to the group for this forum
+        self._init_forum(forum, context)
+
+        # Set up topic
+        topic1 = TopicFactory(forum=forum, poster=user1)
+
+        # Set up post
+        PostFactory.create(
+            topic=topic1,
+            poster=user1,
+        )
+
+        # log user1
+        self.client.force_login(user1)
+
+        # accessing forum view
+        response = self.client.get(reverse("forum:index"))
+        html = lxml.html.fromstring(response.content)
+        forum_last_post = str(etree.tostring(html.cssselect(".forum-last-post")[0]))
+        # control that the administrator's icon is present
+        self.assertTrue(
+            (
+                '<i class="icon_writer fas fa-award" aria-hidden="true" title="Administrator">'
+                '<span class="sr-only">Administrator</span>'
+                "</i>"
+            )
+            in forum_last_post
+        )
+        # control that it's the right user's profile link
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user1.id}/">Val&#233;ry</a>')
+            in forum_last_post
+        )
+
+        # accessing forum topic listing view
+        response = self.client.get(
+            reverse("forum:forum", kwargs={"slug": forum.slug, "pk": forum.pk})
+        )
+        html = lxml.html.fromstring(response.content)
+        # check that the topic creation writer contains the icon for administrator's role
+        topic_created = str(etree.tostring(html.cssselect(".topic-created")[0]))
+        # control that the administrator's icon is present
+        self.assertTrue(
+            (
+                '<i class="icon_writer fas fa-award" aria-hidden="true" title="Administrator">'
+                '<span class="sr-only">Administrator</span>'
+                "</i>"
+            )
+            in topic_created
+        )
+        # control that it's the right user's profile link
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user1.id}/">Val&#233;ry</a>')
+            in topic_created
+        )
+
+        # check that the last post creation writer contains the icon for instructor's role
+        html = lxml.html.fromstring(response.content)
+        topic_last_post = str(etree.tostring(html.cssselect(".topic-last-post")[0]))
+        # control that the administrator's icon is present
+        self.assertTrue(
+            (
+                '<i class="icon_writer fas fa-award" aria-hidden="true" title="Administrator">'
+                '<span class="sr-only">Administrator</span>'
+                "</i>"
+            )
+            in topic_last_post
+        )
+        # control that it's the right user's profile link
+        self.assertTrue(
+            f'<a href="/forum/member/profile/{user1.id}/">Val&#233;ry</a>'
+            in topic_last_post
+        )
+
+        # user2 add a post to the topic, last message is now from a student
+        PostFactory.create(
+            topic=topic1,
+            poster=user2,
+        )
+
+        # reload the topic list view
+        response = self.client.get(
+            reverse("forum:forum", kwargs={"slug": forum.slug, "pk": forum.pk})
+        )
+        html = lxml.html.fromstring(response.content)
+        topic_created = str(etree.tostring(html.cssselect(".topic-created")[0]))
+        # control that the administrator's icon is present
+        self.assertTrue(
+            (
+                '<i class="icon_writer fas fa-award" aria-hidden="true" title="Administrator">'
+                '<span class="sr-only">Administrator</span>'
+                "</i>"
+            )
+            in topic_created
+        )
+        # control that it's the right user's profile link
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user1.id}/">Val&#233;ry</a>')
+            in topic_created
+        )
+
+        topic_last_post = str(etree.tostring(html.cssselect(".topic-last-post")[0]))
+        # check that there's no more icon as the post has been created by a student
+        self.assertFalse("Administrator" in topic_last_post)
+        # control that it's the right user's profile link
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user2.id}/">Fran&#231;ois</a>')
+            in topic_last_post
+        )
+
+        # accessing forum view
+        response = self.client.get(reverse("forum:index"))
+        # check that there's no more icon in this view as a new post has been created by a student
+        self.assertNotContains(response, "icon_writer fas fa-award")
+
+        # access list of posts from the topic
+        response = self.client.get(
+            reverse(
+                "forum_conversation:topic",
+                kwargs={
+                    "forum_slug": forum.slug,
+                    "forum_pk": forum.pk,
+                    "slug": topic1.slug,
+                    "pk": topic1.id,
+                },
+            )
+        )
+        # access 'post an answer' it should list the other posts of the topic
+        response = self.client.get(
+            f"/forum/forum/{forum.slug}-{forum.pk}/topic/{topic1.slug}-{topic1.pk}/post/create/"
+        )
+        html = lxml.html.fromstring(response.content)
+        # check that for the posts in this topic we have the one from the instructor with the icon
+
+        # check that for the message on first position there is no icon for the student
+        html_first_post = str(etree.tostring(html.cssselect(".text-muted")[0]))
+        self.assertFalse("Administrator" in html_first_post)
+        self.assertTrue(
+            (f'<a href="/forum/member/profile/{user2.id}/">Fran&#231;ois</a>')
+            in html_first_post
+        )
+        # check that for the second message we have the instructor's icon
+        html_second_post = str(etree.tostring(html.cssselect(".text-muted")[1]))
+        self.assertTrue(
+            (
+                '<i class="icon_writer fas fa-award" aria-hidden="true" title="Administrator">'
+                '<span class="sr-only">Administrator</span>'
                 "</i>"
             )
             in html_second_post


### PR DESCRIPTION


## Purpose

In previous commit d24b227, an icon has been added to identify
instructors. It will be good to have a logo identifying
administrators as well. Inspired by previous commit d24b227,
we add a ribbon next to their username on topics and posts.


## Proposal

Identify if users are administrators to add a ribbon
