### PR TITLE
💄(front) pagination search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - exclude archived forums from the list of forums of advanced search
 - automatically assign a public_username to instructors and administrators
   when none is defined for a user already existing
+- fix pagination for search results
 
 ## [1.1.0] - 2021-10-28
 

--- a/src/ashley/templates/forum_search/pagination.html
+++ b/src/ashley/templates/forum_search/pagination.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+
+<ul class="m-0 pagination {{ pagination_size|default:"" }}">
+  <li class="page-item{% if not page.has_previous %} disabled{% endif %}">
+    <a href="{% if page.has_previous %}?q={{ query }}&amp;page={{ page.previous_page_number }}{% endif %}" class="page-link">&laquo;</a>
+  </li>
+  {% for number in paginator.page_range %}
+  {% if forloop.first %}
+  <li class="page-item{% if page.number == number %} active{% endif %}"><a href="?q={{ query }}&amp;page={{ number }}" class="page-link">{{ number }}</a></li>
+  {% if page.number > 4 %}
+  <li class="page-item disabled"><a href="#" class="page-link">...</a></li>
+  {% endif %}
+  {% elif forloop.last %}
+  {% if page.number < paginator.num_pages|add:"-3" %}
+  <li class="page-item disabled"><a href="#" class="page-link">...</a></li>
+  {% endif %}
+  <li class="page-item{% if page.number == number %} active{% endif %}"><a href="?q={{ query }}&amp;page={{ number }}" class="page-link">{{ number }}</a></li>
+  {% else %}
+  {% if page.number < 3 and number <= 5 %}
+  <li class="page-item{% if page.number == number %} active{% endif %}"><a href="?q={{ query }}&amp;page={{ number }}" class="page-link">{{ number }}</a></li>
+  {% elif page.number > paginator.num_pages|add:"-2" and number >= paginator.num_pages|add:"-4" %}
+  <li class="page-item{% if page.number == number %} active{% endif %}"><a href="?q={{ query }}&amp;page={{ number }}" class="page-link">{{ number }}</a></li>
+  {% elif number >= page.previous_page_number|add:"-1" and number <= page.next_page_number|add:"1" %}
+  <li class="page-item{% if page.number == number %} active{% endif %}"><a href="?q={{ query }}&amp;page={{ number }}" class="page-link">{{ number }}</a></li>
+  {% endif %}
+  {% endif %}
+  {% endfor %}
+  <li class="page-item{% if not page.has_next %} disabled{% endif %}">
+    <a href="{% if page.has_next %}?q={{ query }}&amp;page={{ page.next_page_number }}{% endif %}" class="page-link">&raquo;</a>
+  </li>
+</ul>


### PR DESCRIPTION


## Purpose

If results were over three pages, <li> tag was missing its closing
tag resulting in a problem of navigation. Some pages were not
accessible anymore.

Resolve https://github.com/openfun/ashley/issues/240


## Proposal

Fix pagination problem
