### PR TITLE
⚡️(back) stop calculating the list of roles for a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Stop calculating the list of roles for the endpoint that list users
+
 ## [1.1.2] - 2022-01-18
 
 ### Added

--- a/src/ashley/api/serializers.py
+++ b/src/ashley/api/serializers.py
@@ -3,8 +3,6 @@ from django.contrib.auth import get_user_model
 from machina.core.db.models import get_model
 from rest_framework import serializers
 
-from ashley.context_mixins import get_current_lti_session
-
 User = get_user_model()
 UploadImage = get_model("ashley", "UploadImage")
 
@@ -12,20 +10,10 @@ UploadImage = get_model("ashley", "UploadImage")
 class UserSerializer(serializers.ModelSerializer):
     """Serializer for User model."""
 
-    roles = serializers.SerializerMethodField()
-
     class Meta:
         model = User
-        fields = ["id", "public_username", "roles"]
-        read_only_fields = ["id", "public_username", "roles"]
-
-    def get_roles(self, obj):
-        """Describes the role of the user"""
-        if obj.is_active:
-            lti_context = get_current_lti_session(self.context.get("request"))
-            return lti_context.get_user_roles(obj)
-
-        return None
+        fields = ["id", "public_username"]
+        read_only_fields = ["id", "public_username"]
 
 
 class UploadImageSerializer(serializers.ModelSerializer):

--- a/src/ashley/api/views.py
+++ b/src/ashley/api/views.py
@@ -9,6 +9,7 @@ from machina.apps.forum_permission.viewmixins import (
 from machina.core.db.models import get_model
 from machina.core.loading import get_class
 from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -60,38 +61,51 @@ class UserApiView(
             )
         return query.order_by(self.ordering)
 
-    # pylint: disable=W0221
-    def update(self, request, pk=None):
-        """Update method is used to promote or revoke moderator role"""
-        user = User.objects.get(pk=pk)
+    @action(detail=True, methods=["patch"])
+    # pylint: disable=unused-argument
+    def remove_group_moderator(
+        self,
+        request,
+        pk=None,
+    ):
+        """Add or remove group moderator."""
+        user = self.get_object()
         lti_context = get_current_lti_session(self.request)
-        roles = self.request.data.get("roles", [])
+        # Asked to revoke moderator,
+        if _FORUM_ROLE_MODERATOR in lti_context.get_user_roles(user):
+            user.groups.remove(lti_context.get_role_group(_FORUM_ROLE_MODERATOR))
+            user.save()
+            return Response(self.get_serializer(user).data)
+        else:
+            raise PermissionDenied()
+            #return Response({"detail": "User is not moderator."}, status=400)
+
+    @action(detail=True, methods=["patch"])
+    # pylint: disable=unused-argument
+    def add_group_moderator(
+        self,
+        request,
+        pk=None,
+    ):
+        
+        """Add or remove group moderator."""
+        #return Response({"success": True}, status=status.HTTP_200_OK)
+        user = self.get_object()
+        
+        lti_context = get_current_lti_session(self.request)
+        
+        
         # Load current groups
         user_groups = lti_context.get_user_roles(user)
-        group_moderator = lti_context.get_role_group(_FORUM_ROLE_MODERATOR)
-
-        # Asked to revoke moderator,
-        if _FORUM_ROLE_MODERATOR not in roles and _FORUM_ROLE_MODERATOR in user_groups:
-            user.groups.remove(group_moderator)
-            user.save()
         # Asked to become moderator, check user is not yet moderator and make sure user
         # belongs to this context by checking he has groups from this context.
-        elif (
-            _FORUM_ROLE_MODERATOR in roles
-            and _FORUM_ROLE_MODERATOR not in user_groups
-            and len(user_groups) > 0
-        ):
-            user.groups.add(group_moderator)
+        if _FORUM_ROLE_MODERATOR not in user_groups and len(user_groups) > 0:
+            user.groups.add(lti_context.get_role_group(_FORUM_ROLE_MODERATOR))
             user.save()
+            return Response(self.get_serializer(user).data)
         else:
-            logger.debug(
-                "Update moderator forbidden - Role asked %s - user groups %s",
-                roles,
-                user_groups,
-            )
             raise PermissionDenied()
-
-        return Response({"success": True}, status=status.HTTP_200_OK)
+            #return Response({"detail": "Group moderator can't be added."}, status=400)
 
 
 # pylint: disable=too-many-ancestors

--- a/src/ashley/permissions.py
+++ b/src/ashley/permissions.py
@@ -24,7 +24,7 @@ class ManageModeratorPermission(PermissionRequiredMixin):
 
     @classmethod
     def _get_forum(cls, request):
-        """LTIContext can have multiple forum, we target the first one"""
+        """LTIContext can have multiple forums, we target the first one"""
         try:
             if request.user.is_authenticated and request.session.get(
                 SESSION_LTI_CONTEXT_ID

--- a/src/frontend/js/components/DashboardModerators/ButtonChangeRoleCta/index.spec.tsx
+++ b/src/frontend/js/components/DashboardModerators/ButtonChangeRoleCta/index.spec.tsx
@@ -8,8 +8,7 @@ import { ButtonChangeRoleCta } from '.';
 const props = {
   user: {
     public_username: 'Samuel',
-    id: 2,
-    roles: ['student'],
+    id: 2
   },
   action: Actions.PROMOTE,
   onChange: jest.fn(),
@@ -41,7 +40,7 @@ describe('<ButtonChangeRoleCta />', () => {
       expect(fetchMock.called('/api/v1.0/users/2/')).toEqual(true);
     });
     expect(fetchMock.lastOptions('/api/v1.0/users/2/')!.body).toEqual(
-      '{"public_username":"Samuel","id":2,"roles":["student","moderator"]}',
+      '{"public_username":"Samuel","id":2}',
     );
     expect(props.onChange).toHaveBeenCalled();
   });
@@ -62,7 +61,7 @@ describe('<ButtonChangeRoleCta />', () => {
       expect(fetchMock.called('/api/v1.0/users/2/')).toEqual(true);
     });
     expect(fetchMock.lastOptions('/api/v1.0/users/2/')!.body).toEqual(
-      '{"public_username":"Samuel","id":2,"roles":["student"]}',
+      '{"public_username":"Samuel","id":2}',
     );
     expect(props.onChange).toHaveBeenCalled();
   });

--- a/src/frontend/js/components/DashboardModerators/ButtonChangeRoleCta/index.tsx
+++ b/src/frontend/js/components/DashboardModerators/ButtonChangeRoleCta/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { messagesDashboardModerators } from '../messages';
-import { Actions, Role } from '../../../types/Enums';
+import { Actions } from '../../../types/Enums';
 import { User } from '../../../types/User';
-import { updateUser } from '../../../data/fetchApi';
+import { updateUserGroup } from '../../../data/fetchApi';
 
 export interface ButtonChangeRoleCtaProps {
   user: User;
@@ -22,19 +22,7 @@ export const ButtonChangeRoleCta = ({
       : messagesDashboardModerators.revokeModerator;
 
   const updateStudent = async () => {
-    // Depending on action submit the requested role
-    switch (action) {
-      case Actions.PROMOTE:
-        user.roles.push(Role.MODERATOR);
-        break;
-      case Actions.REVOKE:
-        const index = user.roles.indexOf(Role.MODERATOR);
-        if (index > -1) {
-          user.roles.splice(index, 1);
-        }
-        break;
-    }
-    const content = await updateUser(user);
+    const content = await updateUserGroup(user, action);
     onChange();
     return content;
   };

--- a/src/frontend/js/components/DashboardModerators/index.spec.tsx
+++ b/src/frontend/js/components/DashboardModerators/index.spec.tsx
@@ -13,17 +13,17 @@ jest.mock('../../data/frontEndData', () => ({
 describe('<DashboardModerators />', () => {
   beforeEach(() => {
     fetchMock.get('/api/v1.0/users/?role=moderator', [
-      { public_username: 'Samy', id: 9, roles: ['moderator'] },
+      { public_username: 'Samy', id: 9},
     ]);
     fetchMock.get('/api/v1.0/users/?role=!moderator', [
-      { public_username: 'Thérèse', id: 1, roles: ['student'] },
-      { public_username: 'thomas', id: 2, roles: ['student'] },
-      { public_username: 'Valérie', id: 3, roles: ['student'] },
-      { public_username: 'Zao', id: 4, roles: ['student'] },
-      { public_username: 'Thibaut', id: 5, roles: ['student'] },
-      { public_username: 'Noémie', id: 6, roles: ['student'] },
-      { public_username: 'Zackari', id: 7, roles: ['student'] },
-      { public_username: 'Zoé', id: 8, roles: ['student'] },
+      { public_username: 'Thérèse', id: 1},
+      { public_username: 'thomas', id: 2 },
+      { public_username: 'Valérie', id: 3 },
+      { public_username: 'Zao', id: 4 },
+      { public_username: 'Thibaut', id: 5},
+      { public_username: 'Noémie', id: 6},
+      { public_username: 'Zackari', id: 7 },
+      { public_username: 'Zoé', id: 8 },
     ]);
   });
 
@@ -120,7 +120,7 @@ describe('<DashboardModerators />', () => {
     });
     expect(fetchMock.called('/api/v1.0/users/6/')).toEqual(true);
     expect(fetchMock.lastOptions('/api/v1.0/users/6/')!.body).toEqual(
-      '{"public_username":"Noémie","id":6,"roles":["student","moderator"]}',
+      '{"public_username":"Noémie","id":6}',
     );
     // make sure current list gets updated
     expect(fetchMock.called('/api/v1.0/users/?role=!moderator')).toEqual(true);

--- a/src/frontend/js/data/fetchApi.ts
+++ b/src/frontend/js/data/fetchApi.ts
@@ -1,6 +1,6 @@
 import { appFrontendContext } from './frontEndData';
 import { User } from '../types/User';
-import { filterApiRole } from '../types/Enums';
+import { Actions, filterApiRole } from '../types/Enums';
 import { handle } from '../utils/errors/handle';
 
 /**
@@ -31,17 +31,17 @@ export const fetchUsers = async (role: filterApiRole) => {
 
 /**
  * Request API to add group moderator for this student
+ * 
  */
-export const updateUser = async (user: User) => {
+export const updateUserGroup = async (user: User, action:Actions) => {
   let response: Response;
   try {
-    response = await fetch(`/api/v1.0/users/${user.id}/`, {
+    response = await fetch(`/api/v1.0/users/{user.id}/{action}/`, {
       headers: {
         'Content-Type': 'application/json',
         'X-CSRFTOKEN': appFrontendContext.csrftoken,
       },
-      body: JSON.stringify(user),
-      method: 'PUT',
+      method: 'PATCH',
     });
   } catch (error) {
     return handle(new Error(`Failed to updateUser ${error}`));

--- a/src/frontend/js/types/Enums.ts
+++ b/src/frontend/js/types/Enums.ts
@@ -1,6 +1,6 @@
 export enum Actions {
-  REVOKE = 'revoke',
-  PROMOTE = 'promote',
+  REVOKE = 'remove_group_moderator',
+  PROMOTE = 'add_group_moderator',
 }
 
 export enum Role {

--- a/src/frontend/js/types/User.ts
+++ b/src/frontend/js/types/User.ts
@@ -1,5 +1,4 @@
 export interface User {
   id: number;
   public_username: string;
-  roles: string[];
 }


### PR DESCRIPTION

## Purpose

Endpoint that lists users that are part of a group were
calculated for each user, the list of the role he was
part of. This implied extra queries for each user of the
list. Ashley can be used with forums that have a lot of
users. Adding systematically this information on querying
listing is not necessary and consumes resources that can
be saved.

## Proposal

stop calculating the list of roles for each users.
