### PR TITLE
Refacto/promote moderators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Stop calculating the list of roles for the endpoint that list users
+
 ## [1.1.2] - 2022-01-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Stop calculating the list of roles for the endpoint that list users
 
+### Added
+
+- Specific endpoints to add and remove group moderator
+
 ## [1.1.2] - 2022-01-18
 
 ### Added

--- a/src/ashley/api/serializers.py
+++ b/src/ashley/api/serializers.py
@@ -3,8 +3,6 @@ from django.contrib.auth import get_user_model
 from machina.core.db.models import get_model
 from rest_framework import serializers
 
-from ashley.context_mixins import get_current_lti_session
-
 User = get_user_model()
 UploadImage = get_model("ashley", "UploadImage")
 
@@ -12,20 +10,10 @@ UploadImage = get_model("ashley", "UploadImage")
 class UserSerializer(serializers.ModelSerializer):
     """Serializer for User model."""
 
-    roles = serializers.SerializerMethodField()
-
     class Meta:
         model = User
-        fields = ["id", "public_username", "roles"]
-        read_only_fields = ["id", "public_username", "roles"]
-
-    def get_roles(self, obj):
-        """Describes the role of the user"""
-        if obj.is_active:
-            lti_context = get_current_lti_session(self.context.get("request"))
-            return lti_context.get_user_roles(obj)
-
-        return None
+        fields = ["id", "public_username"]
+        read_only_fields = ["id", "public_username"]
 
 
 class UploadImageSerializer(serializers.ModelSerializer):

--- a/src/ashley/defaults.py
+++ b/src/ashley/defaults.py
@@ -11,6 +11,7 @@ from ashley.editor.decorators import emoji, image, link, mention
 _FORUM_ROLE_ADMINISTRATOR = "administrator"
 _FORUM_ROLE_INSTRUCTOR = "instructor"
 _FORUM_ROLE_MODERATOR = "moderator"
+_FORUM_ROLE_STUDENT = "student"
 
 _FORUM_BASE_PERMISSIONS = [
     "can_see_forum",

--- a/src/ashley/permissions.py
+++ b/src/ashley/permissions.py
@@ -24,7 +24,7 @@ class ManageModeratorPermission(PermissionRequiredMixin):
 
     @classmethod
     def _get_forum(cls, request):
-        """LTIContext can have multiple forum, we target the first one"""
+        """LTIContext can have multiple forums, we target the first one"""
         try:
             if request.user.is_authenticated and request.session.get(
                 SESSION_LTI_CONTEXT_ID

--- a/src/frontend/js/components/DashboardModerators/ButtonChangeRoleCta/index.spec.tsx
+++ b/src/frontend/js/components/DashboardModerators/ButtonChangeRoleCta/index.spec.tsx
@@ -9,7 +9,6 @@ const props = {
   user: {
     public_username: 'Samuel',
     id: 2,
-    roles: ['student'],
   },
   action: Actions.PROMOTE,
   onChange: jest.fn(),
@@ -26,7 +25,7 @@ describe('<ButtonChangeRoleCta />', () => {
   });
 
   it('renders a button with proper action text depending on props param and calls onChange prop', async () => {
-    fetchMock.mock('/api/v1.0/users/2/', {});
+    fetchMock.mock('/api/v1.0/users/2/add_group_moderator/', {});
     render(
       <IntlProvider locale="en">
         <ButtonChangeRoleCta {...props} />
@@ -38,16 +37,15 @@ describe('<ButtonChangeRoleCta />', () => {
 
     fireEvent.click(button);
     await waitFor(() => {
-      expect(fetchMock.called('/api/v1.0/users/2/')).toEqual(true);
+      expect(
+        fetchMock.called('/api/v1.0/users/2/add_group_moderator/'),
+      ).toEqual(true);
     });
-    expect(fetchMock.lastOptions('/api/v1.0/users/2/')!.body).toEqual(
-      '{"public_username":"Samuel","id":2,"roles":["student","moderator"]}',
-    );
     expect(props.onChange).toHaveBeenCalled();
   });
 
   it('renders a button with proper action text depending on props param and calls onChange prop', async () => {
-    fetchMock.mock('/api/v1.0/users/2/', {});
+    fetchMock.mock('/api/v1.0/users/2/remove_group_moderator/', {});
     render(
       <IntlProvider locale="en">
         <ButtonChangeRoleCta {...{ ...props, action: Actions.REVOKE }} />
@@ -59,11 +57,10 @@ describe('<ButtonChangeRoleCta />', () => {
 
     fireEvent.click(button);
     await waitFor(() => {
-      expect(fetchMock.called('/api/v1.0/users/2/')).toEqual(true);
+      expect(
+        fetchMock.called('/api/v1.0/users/2/remove_group_moderator/'),
+      ).toEqual(true);
     });
-    expect(fetchMock.lastOptions('/api/v1.0/users/2/')!.body).toEqual(
-      '{"public_username":"Samuel","id":2,"roles":["student"]}',
-    );
     expect(props.onChange).toHaveBeenCalled();
   });
 });

--- a/src/frontend/js/components/DashboardModerators/ButtonChangeRoleCta/index.tsx
+++ b/src/frontend/js/components/DashboardModerators/ButtonChangeRoleCta/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { messagesDashboardModerators } from '../messages';
-import { Actions, Role } from '../../../types/Enums';
+import { Actions } from '../../../types/Enums';
 import { User } from '../../../types/User';
-import { updateUser } from '../../../data/fetchApi';
+import { handleUserModeratorGroup } from '../../../data/fetchApi';
 
 export interface ButtonChangeRoleCtaProps {
   user: User;
@@ -22,19 +22,7 @@ export const ButtonChangeRoleCta = ({
       : messagesDashboardModerators.revokeModerator;
 
   const updateStudent = async () => {
-    // Depending on action submit the requested role
-    switch (action) {
-      case Actions.PROMOTE:
-        user.roles.push(Role.MODERATOR);
-        break;
-      case Actions.REVOKE:
-        const index = user.roles.indexOf(Role.MODERATOR);
-        if (index > -1) {
-          user.roles.splice(index, 1);
-        }
-        break;
-    }
-    const content = await updateUser(user);
+    const content = await handleUserModeratorGroup(user, action);
     onChange();
     return content;
   };

--- a/src/frontend/js/components/DashboardModerators/ListModerators/index.spec.tsx
+++ b/src/frontend/js/components/DashboardModerators/ListModerators/index.spec.tsx
@@ -6,9 +6,9 @@ import { ListModerators } from '.';
 const mockSetUser = jest.fn();
 const myProps = {
   users: [
-    { public_username: 'Thérèse', id: 1, roles: ['moderator'] },
-    { public_username: 'Thomas', id: 2, roles: ['moderator'] },
-    { public_username: 'Sam', id: 3, roles: ['moderator'] },
+    { public_username: 'Thérèse', id: 1 },
+    { public_username: 'Thomas', id: 2 },
+    { public_username: 'Sam', id: 3 },
   ],
   totalUsers: 5,
   setUser: mockSetUser,
@@ -51,7 +51,6 @@ describe('<ListModerators />', () => {
     expect(mockSetUser).toHaveBeenCalledWith({
       public_username: 'Thomas',
       id: 2,
-      roles: ['moderator'],
     });
     expect(myProps.onChange).toHaveBeenCalled();
   });
@@ -72,7 +71,7 @@ describe('<ListModerators />', () => {
         <ListModerators
           {...{
             ...myProps,
-            users: [{ public_username: '', id: 3, roles: ['moderator'] }],
+            users: [{ public_username: '', id: 3 }],
           }}
         />
       </IntlProvider>,

--- a/src/frontend/js/components/DashboardModerators/Modal/index.spec.tsx
+++ b/src/frontend/js/components/DashboardModerators/Modal/index.spec.tsx
@@ -71,9 +71,9 @@ describe('<Modal />', () => {
 
   it('calls props.onChange and revoke on click button', async () => {
     fetchMock.mock(
-      '/api/v1.0/users/8/',
+      '/api/v1.0/users/8/remove_group_moderator/',
       { status: 200, body: {} },
-      { method: 'PUT' },
+      { method: 'PATCH' },
     );
     render(
       <IntlProvider locale="en">
@@ -86,19 +86,18 @@ describe('<Modal />', () => {
     });
     fireEvent.click(revokeButton);
     await waitFor(() => {
-      expect(fetchMock.called('/api/v1.0/users/8/')).toEqual(true);
+      expect(
+        fetchMock.called('/api/v1.0/users/8/remove_group_moderator/'),
+      ).toEqual(true);
     });
-    expect(fetchMock.lastOptions('/api/v1.0/users/8/')!.body).toEqual(
-      '{"public_username":"Thérèse","id":8,"roles":["lambda_group","student"]}',
-    );
     expect(myProps.onChange).toHaveBeenCalled();
   });
 
   it('calls props.onChange and promote on click button', async () => {
     fetchMock.mock(
-      '/api/v1.0/users/8/',
+      '/api/v1.0/users/8/add_group_moderator/',
       { status: 200, body: {} },
-      { method: 'PUT' },
+      { method: 'PATCH' },
     );
     render(
       <IntlProvider locale="en">
@@ -106,7 +105,7 @@ describe('<Modal />', () => {
           {...{
             ...myProps,
             action: Actions.PROMOTE,
-            user: { ...myProps.user, roles: ['lambda_group', 'student'] },
+            user: { ...myProps.user },
           }}
         />
       </IntlProvider>,
@@ -117,11 +116,10 @@ describe('<Modal />', () => {
     });
     fireEvent.click(revokeButton);
     await waitFor(() => {
-      expect(fetchMock.called('/api/v1.0/users/8/')).toEqual(true);
+      expect(
+        fetchMock.called('/api/v1.0/users/8/add_group_moderator/'),
+      ).toEqual(true);
     });
-    expect(fetchMock.lastOptions('/api/v1.0/users/8/')!.body).toEqual(
-      '{"public_username":"Thérèse","id":8,"roles":["lambda_group","student","moderator"]}',
-    );
     expect(myProps.onChange).toHaveBeenCalled();
   });
 });

--- a/src/frontend/js/components/DashboardModerators/Modal/index.spec.tsx
+++ b/src/frontend/js/components/DashboardModerators/Modal/index.spec.tsx
@@ -14,7 +14,6 @@ const myProps = {
   user: {
     public_username: 'Thérèse',
     id: 8,
-    roles: ['lambda_group', 'student', 'moderator'],
   },
   action: Actions.REVOKE,
   appElement: '#modal-exclude__react',

--- a/src/frontend/js/components/DashboardModerators/Moderator/index.spec.tsx
+++ b/src/frontend/js/components/DashboardModerators/Moderator/index.spec.tsx
@@ -9,7 +9,6 @@ const props = {
   user: {
     public_username: 'Samuel',
     id: 2,
-    roles: ['moderator'],
   },
   onClick: mockOnClick,
 };
@@ -34,7 +33,6 @@ describe('<Moderator />', () => {
     expect(mockOnClick).toHaveBeenCalledWith({
       public_username: 'Samuel',
       id: 2,
-      roles: ['moderator'],
     });
   });
 });

--- a/src/frontend/js/components/DashboardModerators/SelectStudentsSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/DashboardModerators/SelectStudentsSuggestField/index.spec.tsx
@@ -6,14 +6,14 @@ import { SelectStudentsSuggestField } from '.';
 const mockSetUser = jest.fn();
 const myProps = {
   users: [
-    { public_username: 'Thérèse', id: 1, roles: ['student'] },
-    { public_username: 'thomas', id: 2, roles: ['student'] },
-    { public_username: 'Valérie', id: 3, roles: ['student'] },
-    { public_username: 'Zao', id: 4, roles: ['student'] },
-    { public_username: 'Thibaut', id: 5, roles: ['student'] },
-    { public_username: 'Noémie', id: 6, roles: ['student'] },
-    { public_username: 'Zackari', id: 7, roles: ['student'] },
-    { public_username: 'Zoé', id: 8, roles: ['student'] },
+    { public_username: 'Thérèse', id: 1 },
+    { public_username: 'thomas', id: 2 },
+    { public_username: 'Valérie', id: 3 },
+    { public_username: 'Zao', id: 4 },
+    { public_username: 'Thibaut', id: 5 },
+    { public_username: 'Noémie', id: 6 },
+    { public_username: 'Zackari', id: 7 },
+    { public_username: 'Zoé', id: 8 },
   ],
   setUser: mockSetUser,
   onChange: jest.fn(),
@@ -111,7 +111,6 @@ describe('<SelectStudentsSuggestField />', () => {
     expect(mockSetUser).toHaveBeenCalledWith({
       public_username: 'Noémie',
       id: 6,
-      roles: ['student'],
     });
   });
 });

--- a/src/frontend/js/components/DashboardModerators/index.spec.tsx
+++ b/src/frontend/js/components/DashboardModerators/index.spec.tsx
@@ -89,9 +89,9 @@ describe('<DashboardModerators />', () => {
   });
   it('renders the Modal from selecting a user and on validation list gets updated', async () => {
     fetchMock.mock(
-      '/api/v1.0/users/6/',
+      '/api/v1.0/users/6/add_group_moderator/',
       { status: 200, body: {} },
-      { method: 'PUT' },
+      { method: 'PATCH' },
     );
 
     render(
@@ -118,9 +118,8 @@ describe('<DashboardModerators />', () => {
     await waitFor(() => {
       fireEvent.click(promoteModerator);
     });
-    expect(fetchMock.called('/api/v1.0/users/6/')).toEqual(true);
-    expect(fetchMock.lastOptions('/api/v1.0/users/6/')!.body).toEqual(
-      '{"public_username":"Noémie","id":6,"roles":["student","moderator"]}',
+    expect(fetchMock.called('/api/v1.0/users/6/add_group_moderator/')).toEqual(
+      true,
     );
     // make sure current list gets updated
     expect(fetchMock.called('/api/v1.0/users/?role=!moderator')).toEqual(true);

--- a/src/frontend/js/components/DashboardModerators/index.spec.tsx
+++ b/src/frontend/js/components/DashboardModerators/index.spec.tsx
@@ -13,17 +13,17 @@ jest.mock('../../data/frontEndData', () => ({
 describe('<DashboardModerators />', () => {
   beforeEach(() => {
     fetchMock.get('/api/v1.0/users/?role=moderator', [
-      { public_username: 'Samy', id: 9, roles: ['moderator'] },
+      { public_username: 'Samy', id: 9 },
     ]);
     fetchMock.get('/api/v1.0/users/?role=!moderator', [
-      { public_username: 'Thérèse', id: 1, roles: ['student'] },
-      { public_username: 'thomas', id: 2, roles: ['student'] },
-      { public_username: 'Valérie', id: 3, roles: ['student'] },
-      { public_username: 'Zao', id: 4, roles: ['student'] },
-      { public_username: 'Thibaut', id: 5, roles: ['student'] },
-      { public_username: 'Noémie', id: 6, roles: ['student'] },
-      { public_username: 'Zackari', id: 7, roles: ['student'] },
-      { public_username: 'Zoé', id: 8, roles: ['student'] },
+      { public_username: 'Thérèse', id: 1 },
+      { public_username: 'thomas', id: 2 },
+      { public_username: 'Valérie', id: 3 },
+      { public_username: 'Zao', id: 4 },
+      { public_username: 'Thibaut', id: 5 },
+      { public_username: 'Noémie', id: 6 },
+      { public_username: 'Zackari', id: 7 },
+      { public_username: 'Zoé', id: 8 },
     ]);
   });
 

--- a/src/frontend/js/data/fetchApi.ts
+++ b/src/frontend/js/data/fetchApi.ts
@@ -1,6 +1,6 @@
 import { appFrontendContext } from './frontEndData';
 import { User } from '../types/User';
-import { filterApiRole } from '../types/Enums';
+import { Actions, filterApiRole } from '../types/Enums';
 import { handle } from '../utils/errors/handle';
 
 /**
@@ -31,17 +31,17 @@ export const fetchUsers = async (role: filterApiRole) => {
 
 /**
  * Request API to add group moderator for this student
+ *
  */
-export const updateUser = async (user: User) => {
+export const handleUserModeratorGroup = async (user: User, action: Actions) => {
   let response: Response;
   try {
-    response = await fetch(`/api/v1.0/users/${user.id}/`, {
+    response = await fetch(`/api/v1.0/users/${user.id}/${action}/`, {
       headers: {
         'Content-Type': 'application/json',
         'X-CSRFTOKEN': appFrontendContext.csrftoken,
       },
-      body: JSON.stringify(user),
-      method: 'PUT',
+      method: 'PATCH',
     });
   } catch (error) {
     return handle(new Error(`Failed to updateUser ${error}`));

--- a/src/frontend/js/types/Enums.ts
+++ b/src/frontend/js/types/Enums.ts
@@ -1,6 +1,6 @@
 export enum Actions {
-  REVOKE = 'revoke',
-  PROMOTE = 'promote',
+  REVOKE = 'remove_group_moderator',
+  PROMOTE = 'add_group_moderator',
 }
 
 export enum Role {

--- a/src/frontend/js/types/User.ts
+++ b/src/frontend/js/types/User.ts
@@ -1,5 +1,4 @@
 export interface User {
   id: number;
   public_username: string;
-  roles: string[];
 }

--- a/tests/ashley/api/test_api_manage_moderators.py
+++ b/tests/ashley/api/test_api_manage_moderators.py
@@ -609,58 +609,74 @@ class ManageModeratorApiTest(TestCase):
         lti_context.sync_user_groups(user3, ["student", "moderator"]),
         lti_context.sync_user_groups(user4, ["instructor"])
 
-        # Request with no filter returns the list of users but user5 that has no roles
-        # list ordered by public_username
-        response = self.client.get("/api/v1.0/users/", content_type="application/json")
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-        self.assertEqual(
-            content,
-            [
-                {
-                    "id": user3.id,
-                    "public_username": "Abba",
-                    "roles": ["moderator", "student"],
-                },
-                {"id": user2.id, "public_username": "Aurélie", "roles": ["student"]},
-                {"id": user4.id, "public_username": "Silvio", "roles": ["instructor"]},
-                {"id": user1.id, "public_username": "Thomas", "roles": ["student"]},
-            ],
-        )
+        with self.assertNumQueries(9):
+            # Request with no filter returns the list of users but user5 that has no roles
+            # list ordered by public_username
+            response = self.client.get(
+                "/api/v1.0/users/", content_type="application/json"
+            )
+            self.assertEqual(response.status_code, 200)
+            content = json.loads(response.content)
+            self.assertEqual(
+                content,
+                [
+                    {
+                        "id": user3.id,
+                        "public_username": "Abba",
+                    },
+                    {"id": user2.id, "public_username": "Aurélie"},
+                    {"id": user4.id, "public_username": "Silvio"},
+                    {"id": user1.id, "public_username": "Thomas"},
+                ],
+            )
 
-        response = self.client.get(
-            "/api/v1.0/users/?role=student", content_type="application/json"
-        )
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-        self.assertEqual(
-            content,
-            [
-                {
-                    "id": user3.id,
-                    "public_username": "Abba",
-                    "roles": ["moderator", "student"],
-                },
-                {"id": user2.id, "public_username": "Aurélie", "roles": ["student"]},
-                {"id": user1.id, "public_username": "Thomas", "roles": ["student"]},
-            ],
-        )
+        with self.assertNumQueries(9):
+            response = self.client.get(
+                "/api/v1.0/users/?role=student", content_type="application/json"
+            )
+            self.assertEqual(response.status_code, 200)
+            content = json.loads(response.content)
+            self.assertEqual(
+                content,
+                [
+                    {
+                        "id": user3.id,
+                        "public_username": "Abba",
+                    },
+                    {"id": user2.id, "public_username": "Aurélie"},
+                    {"id": user1.id, "public_username": "Thomas"},
+                ],
+            )
 
-        response = self.client.get(
-            "/api/v1.0/users/?role=moderator", content_type="application/json"
-        )
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-        self.assertEqual(
-            content,
-            [
-                {
-                    "id": user3.id,
-                    "public_username": "Abba",
-                    "roles": ["moderator", "student"],
-                },
-            ],
-        )
+        with self.assertNumQueries(9):
+            response = self.client.get(
+                "/api/v1.0/users/?role=moderator", content_type="application/json"
+            )
+            self.assertEqual(response.status_code, 200)
+            content = json.loads(response.content)
+            self.assertEqual(
+                content,
+                [
+                    {
+                        "id": user3.id,
+                        "public_username": "Abba",
+                    },
+                ],
+            )
+
+        with self.assertNumQueries(9):
+            response = self.client.get(
+                "/api/v1.0/users/?role=!moderator", content_type="application/json"
+            )
+            self.assertEqual(response.status_code, 200)
+            content = json.loads(response.content)
+            self.assertEqual(
+                content,
+                [
+                    {"id": user2.id, "public_username": "Aurélie"},
+                    {"id": user1.id, "public_username": "Thomas"},
+                ],
+            )
 
         response = self.client.get(
             "/api/v1.0/users/?role=instructor", content_type="application/json"
@@ -670,7 +686,7 @@ class ManageModeratorApiTest(TestCase):
         self.assertEqual(
             content,
             [
-                {"id": user4.id, "public_username": "Silvio", "roles": ["instructor"]},
+                {"id": user4.id, "public_username": "Silvio"},
             ],
         )
 
@@ -696,7 +712,6 @@ class ManageModeratorApiTest(TestCase):
                 {
                     "id": user1.id,
                     "public_username": "Thomas",
-                    "roles": ["moderator", "student"],
                 },
             ],
         )
@@ -712,7 +727,6 @@ class ManageModeratorApiTest(TestCase):
                 {
                     "id": user1.id,
                     "public_username": "Thomas",
-                    "roles": ["moderator", "student"],
                 },
             ],
         )
@@ -738,7 +752,6 @@ class ManageModeratorApiTest(TestCase):
                 {
                     "id": user1.id,
                     "public_username": "Thomas",
-                    "roles": ["moderator", "student"],
                 },
             ],
         )
@@ -796,7 +809,6 @@ class ManageModeratorApiTest(TestCase):
                 {
                     "id": user1.id,
                     "public_username": "Thomas",
-                    "roles": ["instructor", "moderator"],
                 },
             ],
         )
@@ -821,7 +833,6 @@ class ManageModeratorApiTest(TestCase):
                 {
                     "id": user1.id,
                     "public_username": "Thomas",
-                    "roles": ["instructor", "moderator"],
                 },
             ],
         )
@@ -902,7 +913,7 @@ class ManageModeratorApiTest(TestCase):
         # from this context
         self.assertEqual(
             content,
-            [{"id": user1.id, "public_username": "Thomas", "roles": ["moderator"]}],
+            [{"id": user1.id, "public_username": "Thomas"}],
         )
 
         # request all users
@@ -913,7 +924,7 @@ class ManageModeratorApiTest(TestCase):
         # from this context
         self.assertEqual(
             content,
-            [{"id": user1.id, "public_username": "Thomas", "roles": ["moderator"]}],
+            [{"id": user1.id, "public_username": "Thomas"}],
         )
 
         # request all users that are not moderators
@@ -961,9 +972,8 @@ class ManageModeratorApiTest(TestCase):
                 {
                     "id": user2.id,
                     "public_username": "Aurélie",
-                    "roles": ["moderator", "student"],
                 },
-                {"id": user1.id, "public_username": "Thomas", "roles": ["student"]},
+                {"id": user1.id, "public_username": "Thomas"},
             ],
         )
         # only active moderator is listed
@@ -978,7 +988,6 @@ class ManageModeratorApiTest(TestCase):
                 {
                     "id": user2.id,
                     "public_username": "Aurélie",
-                    "roles": ["moderator", "student"],
                 }
             ],
         )
@@ -994,7 +1003,6 @@ class ManageModeratorApiTest(TestCase):
                 {
                     "id": user5.id,
                     "public_username": "Théo",
-                    "roles": ["instructor", "moderator"],
                 }
             ],
         )
@@ -1007,7 +1015,7 @@ class ManageModeratorApiTest(TestCase):
         content = json.loads(response.content)
         self.assertEqual(
             content,
-            [{"id": user1.id, "public_username": "Thomas", "roles": ["student"]}],
+            [{"id": user1.id, "public_username": "Thomas"}],
         )
 
     def test_api_can_manage_moderators_update_student_public_username_readonly(


### PR DESCRIPTION
## Purpose

The endpoint that lists users that are part of a group was
calculated for each user the list of the role he was
part of. This implied extra queries for each user of the
list. Ashley can be used with forums that have a lot of
participants. Adding systematically this information on
querying listing is not necessary and consumes resources
that can be saved.
We create two new endpoints so that we can directly target adding
or removing the group moderator for a user.

## Proposal

- stop calculating roles of users in the serializer
- create two new endpoints add_group_moderator, remove_group_moderator
