### PR TITLE
🐛(back) search queries restricted on LTIContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Specific endpoints to add and remove group moderator
 
+### Fixed
+
+- search queries to check user's permissions restricted on LTIContext
+
 ## [1.1.2] - 2022-01-18
 
 ### Added

--- a/src/ashley/machina_extensions/forum_permission/handler.py
+++ b/src/ashley/machina_extensions/forum_permission/handler.py
@@ -49,9 +49,10 @@ class PermissionHandler(BasePermissionHandler):
         """
         forums_to_show = super().forum_list_filter(qs, user)
         if self.current_lti_context_id:
-            return forums_to_show.filter(archived=False).filter(
-                lti_contexts__id=self.current_lti_context_id
+            return forums_to_show.filter(
+                archived=False, lti_contexts__id=self.current_lti_context_id
             )
+
         return forums_to_show
 
     def get_readable_forums(self, forums, user):
@@ -61,24 +62,104 @@ class PermissionHandler(BasePermissionHandler):
 
         We override django machina's method to filter forums based on the
         current LTI context of the User, if any.
+
         """
-        readable_forums = super().get_readable_forums(forums, user)
+
+        if user.is_superuser:
+            readable_forums = forums.filter(archived=False)
+        else:
+            # Fetches the forums that can be read by the given user.
+            readable_forums = self._get_forums_for_user_with_lti_forums(
+                forums,
+                user,
+                [
+                    "can_read_forum",
+                ],
+                True,
+            )
+            readable_forums = (
+                forums.filter(id__in=[f.id for f in readable_forums])
+                if isinstance(forums, (models.Manager, models.QuerySet))
+                else list(filter(lambda f: f in readable_forums, forums))
+            )
+
         if self.current_lti_context_id:
-            if isinstance(forums, (models.Manager, models.QuerySet)):
+            if isinstance(readable_forums, (models.Manager, models.QuerySet)):
                 return readable_forums.filter(
-                    lti_contexts__id=self.current_lti_context_id
+                    archived=False, lti_contexts__id=self.current_lti_context_id
                 )
             return list(
                 filter(
                     lambda f: any(
                         x
                         for x in f.lti_contexts.all()
-                        if x.id == self.current_lti_context_id
+                        if x.id == self.current_lti_context_id and not f.archived
                     ),
                     readable_forums,
                 )
             )
+
         return readable_forums
+
+    def _get_forums_for_user(self, user, perm_codenames, use_tree_hierarchy=False):
+        """Returns all the forums that satisfy the given list of permission codenames.
+
+        User and group forum permissions are used.
+
+        If the ``use_tree_hierarchy`` keyword argument is set the granted forums will be filtered
+        so that a forum which has an ancestor which is not in the granted forums set will not be
+        returned.
+
+        We override django machina's method to filter forums based on the
+        current LTI context of the User, if any and to automatically exclude archived forums.
+
+        """
+        forums = Forum.objects.filter(archived=False)
+        if self.current_lti_context_id:
+            forums = forums.filter(lti_contexts__id=self.current_lti_context_id)
+        return self._get_forums_for_user_with_lti_forums(
+            forums, user, perm_codenames, use_tree_hierarchy
+        )
+
+    def _get_forums_for_user_with_lti_forums(
+        self, filtered_forums, user, perm_codenames, use_tree_hierarchy=False
+    ):
+        """Returns for the list of forum based on filtered_forums that satisfy the given
+        list of permission codenames.
+
+        User and group forum permissions are used.
+
+        If the ``use_tree_hierarchy`` keyword argument is set the granted forums will be filtered
+        so that a forum which has an ancestor which is not in the granted forums set will not be
+        returned.
+
+        """
+        granted_forums_cache_key = "{}__{}".format(
+            ":".join(perm_codenames),
+            user.id if not user.is_anonymous else "anonymous",
+        )
+
+        if granted_forums_cache_key in self._granted_forums_cache:
+            return self._granted_forums_cache[granted_forums_cache_key]
+
+        # First check if the user is a superuser and if so, returns the forum queryset immediately.
+        if user.is_superuser:  # pragma: no cover
+            self._granted_forums_cache[granted_forums_cache_key] = filtered_forums
+            return filtered_forums
+
+        checker = self._get_checker(user)
+        perms = checker.get_perms_for_forumlist(filtered_forums, perm_codenames)
+        allowed_forums = []
+        # Check if the requested permissions are in the set of permissions for the forum
+        for _f in filtered_forums:
+            if set(perm_codenames).issubset(perms[_f]):
+                allowed_forums.append(_f)
+
+        if use_tree_hierarchy:
+            allowed_forums = self._filter_granted_forums_using_tree(allowed_forums)
+
+        self._granted_forums_cache[granted_forums_cache_key] = allowed_forums
+        return allowed_forums
 
     # pylint:disable = W0201
     def _get_all_forums(self):

--- a/src/ashley/machina_extensions/forum_search/forms.py
+++ b/src/ashley/machina_extensions/forum_search/forms.py
@@ -3,6 +3,7 @@
     ==================
     This module defines forms provided by the ``forum_search`` application.
 """
+from django.utils.translation import gettext_lazy as _
 from machina.apps.forum_search.forms import SearchForm as MachinaSearchForm
 from machina.core.db.models import get_model
 from machina.core.loading import get_class
@@ -13,28 +14,33 @@ PermissionHandler = get_class("forum_permission.handler", "PermissionHandler")
 
 class SearchForm(MachinaSearchForm):
     """
-    Override Django Machina's SearchForm to allow searching poster user names
+    Allows to search forum topics and posts and allows searching poster user names
     even with an empty search in the main field.
     """
 
     def __init__(self, *args, **kwargs):
-        """
-        Init form, code based on base class MachinaSearchForm. A filter on lti_context
-        has been added.
-        """
-        # Loads current lti_context to filter forum search
-        lti_contexts = kwargs.pop("lti_context", None)
-        super().__init__(*args, **kwargs)
         user = kwargs.pop("user", None)
+        lti_contexts = kwargs.pop("lti_context", None)
+
+        # pylint: disable=bad-super-call
+        super(MachinaSearchForm, self).__init__(*args, **kwargs)
+
+        # Update some fields
+        self.fields["q"].label = _("Search for keywords")
+        self.fields["q"].widget.attrs["placeholder"] = _("Keywords or phrase")
+        self.fields["search_poster_name"].widget.attrs["placeholder"] = _("Poster name")
+
         self.allowed_forums = PermissionHandler().get_readable_forums(
             Forum.objects.filter(archived=False, lti_contexts=lti_contexts), user
         )
-        # self.allowed_forums is used in search method of MachinaSearchForm
         if self.allowed_forums:
             self.fields["search_forums"].choices = [
                 (f.id, "{} {}".format("-" * f.margin_level, f.name))
                 for f in self.allowed_forums
             ]
+        else:
+            # The user cannot view any single forum, the 'search_forums' field can be deleted
+            del self.fields["search_forums"]
 
     def clean(self):
         """


### PR DESCRIPTION

## Purpose

If a user was part of multiple courses, search queries were
taking a lot of processing time. DjangoMachina checks the
permissions of the user for each forum he has access to. We only
need to control that the user has the permission to read the forums
part of the current LTIContext. By limiting this query, we fix
at the same time, the problem of the processing time.
With this new method overridden from DjangoMachina, we exclude as
well archived forums.


## Proposal

limit queries with lti_context and archived forums
