### PR TITLE
✨(forum) search links target directly the refered post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Specific endpoints to add and remove group moderator
+- Search results directly target the page of the topic of the related post
 
 ### Fixed
 

--- a/src/ashley/templates/forum_search/search.html
+++ b/src/ashley/templates/forum_search/search.html
@@ -75,7 +75,7 @@
           {% for result in page.object_list %}
           <tr>
             <td class="post-name">
-              <a href="{% url 'forum_conversation:topic' result.forum_slug result.forum result.topic_slug result.topic %}" class="topic-name-link">{{ result.topic_subject }}</a>
+              <a href="{% url 'forum_conversation:topic' result.forum_slug result.forum result.topic_slug result.topic %}?post={{ result.pk }}#{{ result.pk }}" class="topic-name-link">{{ result.topic_subject }}</a>
               <div>
                 <div class="post-created">
                   {% if result.poster %}


### PR DESCRIPTION

## Purpose

A topic can have multiple posts and a lot of pages. Search results were targeting the topic on page 1 for any match.
If the post matching the search was on page 10, it made it hard to relate the search and the post. In this condition,
the results didn't seem accurate. To be more precise, we now build a link that directly targets the post on the right
page in the topic.

## Proposal

- build a direct link targeting the post
