### PR TITLE
💄(lock course) spaces between forums names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+
+### Changed
+
+- Reduce spaces between forums names on the lock page
+
 ## [1.2.2] - 2022-06-08
 
 ### Fixed

--- a/src/ashley/templates/forum/forum_lock.html
+++ b/src/ashley/templates/forum/forum_lock.html
@@ -13,7 +13,7 @@
       <div class="card-body">
           <div class="mb-3 warning-message">
               <p>{% trans "Are you sure you want to lock the entire course? All the forums in this course will be locked." %}</p>
-              {% for forum in forums_list %}<p class="ml-3 pb-3"><strong>{{ forum.name }}</strong><p>{% endfor %}
+              {% for forum in forums_list %}<p class="ml-3 mb-0"><strong>{{ forum.name }}</strong></p>{% endfor %}
           </div>
         <form method="post" action="." class="form" enctype="multipart/form-data" novalidate>{% csrf_token %}
           <div class="row">

--- a/tests/ashley/test_course_locked.py
+++ b/tests/ashley/test_course_locked.py
@@ -788,9 +788,9 @@ class CourseLockCase(TestCase):
         self.assertEqual(200, response.status_code)
         # this listing is common for all the forums of the course
         forums_list = (
-            f'<p class="ml-3 pb-3"><strong>{forum1.name}</strong><p>'
-            '<p class="ml-3 pb-3"><strong>Forum2</strong><p>'
-            '<p class="ml-3 pb-3"><strong>Forum3</strong><p>'
+            f'<p class="ml-3 mb-0"><strong>{forum1.name}</strong></p>'
+            '<p class="ml-3 mb-0"><strong>Forum2</strong></p>'
+            '<p class="ml-3 mb-0"><strong>Forum3</strong></p>'
         )
         self.assertContains(response, forums_list)
 


### PR DESCRIPTION


## Purpose

When a course has multiple forums, the listing can be
very long. We don't want the user to have to scroll
too much before showing the confirmation button to
lock the course.


## Proposal

change margin and padding
