### PR TITLE
✨(admin) display lti_id of a forum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Allow unlocking all forums of a course
+- Display lti_id field on the forum admin panel
 
 ## [1.2.3] - 2022-06-13
 

--- a/src/ashley/machina_extensions/forum/admin.py
+++ b/src/ashley/machina_extensions/forum/admin.py
@@ -1,6 +1,29 @@
 """
 Import the admin classes from the django-machina's forum application
 """
+import copy
 
-# pylint: disable=unused-wildcard-import,wildcard-import
-from machina.apps.forum.admin import *  # noqa isort:skip
+from django.contrib import admin
+from machina.apps.forum.admin import ForumAdmin as BaseForumAdmin
+from machina.core.db.models import get_model
+
+Forum = get_model("forum", "Forum")
+
+admin.site.unregister(Forum)
+
+
+class ForumAdmin(BaseForumAdmin):
+    """The Forum model admin."""
+
+    readonly_fields = ("lti_id",)
+    search_fields = ("name", "lti_id")
+
+    def get_fieldsets(self, request, obj=None):
+        """Override fieldset to add the field lti_id"""
+        fieldsets = copy.deepcopy(super().get_fieldsets(request, obj))
+        fieldsets[0][1]["fields"] = (*fieldsets[0][1]["fields"], "lti_id")
+
+        return fieldsets
+
+
+admin.site.register(Forum, ForumAdmin)

--- a/tests/ashley/test_admin.py
+++ b/tests/ashley/test_admin.py
@@ -1,0 +1,27 @@
+"""Test suite for the Forum admin"""
+from django.test import TestCase
+from machina.core.db.models import get_model
+
+from ashley.factories import ForumFactory, LTIContextFactory, UserFactory
+
+LTIContext = get_model("ashley", "LTIContext")
+Forum = get_model("forum", "Forum")
+
+
+class TestForumAdmin(TestCase):
+    """Test for the Forum admin"""
+
+    def test_show_lti(self):
+        """Control lti_id field is display"""
+        user = UserFactory(is_superuser=True, is_staff=True)
+        self.client.force_login(user)
+
+        lti_context = LTIContextFactory(lti_consumer=user.lti_consumer)
+        forum = ForumFactory()
+        forum.lti_contexts.add(lti_context)
+        url = f"/admin/forum/forum/{forum.id}/change/"
+        response = self.client.get(url)
+
+        self.assertContains(
+            response, f'<div class="readonly">{forum.lti_id}</div>', html=True
+        )


### PR DESCRIPTION

## Purpose

The URL of a forum is built using its lti_id. 
Displaying the field lti_id of a forum enables an administrator to have 
access to this useful information.



## Proposal

- override admin django machina to add the field lti_id
