### PR TITLE
🐛(front) fonts for katex lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,9 @@ COPY --from=front-builder \
 COPY --from=front-builder \
     /builder/src/ashley/static/ashley/font/* \
     /builder/src/ashley/static/ashley/font/
+COPY --from=front-builder \
+    /builder/src/ashley/static/ashley/css/fonts/* \
+    /builder/src/ashley/static/ashley/css/fonts/
 
 RUN mkdir /install && \
     pip install --prefix=/install .[sandbox]

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -14,7 +14,7 @@
     "lint-all": "yarn lint-fix && yarn prettier-write",
     "sass": "node-sass --include-path node_modules scss/_main.scss ../ashley/static/ashley/css/main.css",
     "sass-production": "node-sass --include-path node_modules scss/_main.scss --output-style compressed ../ashley/static/ashley/css/main.css",
-    "webfonts": "mkdir -p ../ashley/static/ashley/font/ && cp -f ./node_modules/@fortawesome/fontawesome-free/webfonts/* ../ashley/static/ashley/font/",
+    "webfonts": "mkdir -p ../ashley/static/ashley/font/ ../ashley/static/ashley/css/fonts/ && cp -f ./node_modules/@fortawesome/fontawesome-free/webfonts/* ../ashley/static/ashley/font/ && cp -f ./node_modules/katex/dist/fonts/* ../ashley/static/ashley/css/fonts/",
     "test": "jest",
     "watch-sass": "nodemon -e scss -x 'yarn sass'"
   },


### PR DESCRIPTION

## Purpose

Katex npm package is using fonts. These files need to be uploaded into the static folder of django.


## Proposal

Copy fonts in the static folder
