### PR TITLE
Feat/bug image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix converting in HTML atomic blocks for images
+
 ## [1.3.0] - 2023-02-07
 
 ### Added

--- a/src/ashley/defaults.py
+++ b/src/ashley/defaults.py
@@ -7,12 +7,12 @@ from draftjs_exporter.defaults import STYLE_MAP as DEFAULT_STYLE_MAP
 from draftjs_exporter.dom import DOM
 
 from ashley.editor.decorators import (
+    ashley_render_children,
     emoji,
     image,
     inlinetex,
     link,
     mention,
-    render_children,
 )
 
 _FORUM_ROLE_ADMINISTRATOR = "administrator"
@@ -108,7 +108,7 @@ DEFAULT_DRAFTJS_EXPORTER_CONFIG = {
     "block_map": dict(
         DEFAULT_BLOCK_MAP,
         **{
-            "atomic": render_children,
+            "atomic": ashley_render_children,
         },
     ),
     "style_map": DEFAULT_STYLE_MAP,

--- a/src/ashley/editor/decorators.py
+++ b/src/ashley/editor/decorators.py
@@ -1,6 +1,7 @@
 """This module contains custom decorators for draftjs_exporter."""
 import logging
 
+from draftjs_exporter.defaults import render_children
 from draftjs_exporter.dom import DOM
 
 logger = logging.getLogger(__name__)
@@ -104,17 +105,16 @@ def inlinetex(props):
     )
 
 
-def render_children(props):
+def ashley_render_children(props):
     """
     Decorator for the blocks in Draft.js ContentState. TEXBLOCK is a custom
     block that is used through atomic blocks.
     """
-    if props.get("block").get("data").get("type") == "TEXBLOCK":
+    if props.get("block", {}).get("data", {}).get("type") == "TEXBLOCK":
         return DOM.create_element(
             "span",
             {"class": "ashley-latex-display"},
             props.get("block").get("data").get("tex", None),
         )
-
     # default behaviour
-    return props
+    return render_children(props)

--- a/tests/ashley/draftjs_exporter/test_draftjs_exporter_decorator_latex.py
+++ b/tests/ashley/draftjs_exporter/test_draftjs_exporter_decorator_latex.py
@@ -1,7 +1,9 @@
+from unittest import mock
+
 from django.test import TestCase
 from draftjs_exporter.dom import DOM
 
-from ashley.editor.decorators import inlinetex, render_children
+from ashley.editor.decorators import ashley_render_children, inlinetex
 
 
 class TestInlinetexDecorator(TestCase):
@@ -40,7 +42,7 @@ class TestInlinetexDecorator(TestCase):
 
     def test_custom_decorator_displaytex_ok(self):
         """
-        check custom decorator for `render_children` of tex returns expected html
+        check custom decorator for `ashley_render_children` of tex returns expected html
         """
 
         tex = "\left.\frac{x^3}{3}\right|_0^1"  # noqa: W605
@@ -48,7 +50,7 @@ class TestInlinetexDecorator(TestCase):
         self.assertEqual(
             DOM.render(
                 DOM.create_element(
-                    render_children,
+                    ashley_render_children,
                     {
                         "block": {
                             "key": "a215p",
@@ -70,7 +72,7 @@ class TestInlinetexDecorator(TestCase):
         self.assertEqual(
             DOM.render(
                 DOM.create_element(
-                    render_children,
+                    ashley_render_children,
                     {
                         "block": {
                             "key": "a215p",
@@ -86,13 +88,13 @@ class TestInlinetexDecorator(TestCase):
 
     def test_custom_decorator_displaytex_no_maths(self):
         """
-        check custom decorator `render_children` returns expected html even when
+        check custom decorator `ashley_render_children` returns expected html even when
         the content is not a formula but a regular string
         """
         self.assertEqual(
             DOM.render(
                 DOM.create_element(
-                    render_children,
+                    ashley_render_children,
                     {
                         "block": {
                             "key": "a215p",
@@ -108,13 +110,13 @@ class TestInlinetexDecorator(TestCase):
 
     def test_custom_decorator_displaytex_no_malformed(self):
         """
-        check custom decorator `render_children` returns expected html even when
+        check custom decorator `ashley_render_children` returns expected html even when
         the `tex` attribute is missing
         """
         self.assertEqual(
             DOM.render(
                 DOM.create_element(
-                    render_children,
+                    ashley_render_children,
                     {
                         "block": {
                             "key": "a215p",
@@ -126,4 +128,31 @@ class TestInlinetexDecorator(TestCase):
                 )
             ),
             '<span class="ashley-latex-display"></span>',
+        )
+
+    @mock.patch("ashley.editor.decorators.render_children")
+    def test_custom_decorator_atomic_other_mock_render_children(
+        self, mock_render_children
+    ):
+        """
+        check custom decorator `ashley_render_children` returns expected html by rendering
+        render_children of the draftjs_exporter in case of atomic block used for other type than
+        type TEXBLOCK
+        """
+        props = {
+            "block": {
+                "key": "ahfcc",
+                "text": " ",
+                "type": "atomic",
+                "depth": 0,
+                "inlineStyleRanges": [],
+                "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+                "data": {},
+            },
+        }
+        mock_render_children.return_value = "mocked children"
+
+        self.assertEqual(
+            ashley_render_children(props),
+            "mocked children",
         )

--- a/tests/ashley/draftjs_exporter/test_draftjs_exporter_renderer.py
+++ b/tests/ashley/draftjs_exporter/test_draftjs_exporter_renderer.py
@@ -1,0 +1,196 @@
+import json
+
+from django.test import TestCase
+
+from ashley.editor import draftjs_renderer
+
+
+class TestDraftJsRenderer(TestCase):
+    """Test draftjs_renderer method used to render draftjs content"""
+
+    def test_draftjs_renderer_valid_json(self):
+        """draftjs_renderer should return valid html"""
+        content = {
+            "entityMap": {},
+            "blocks": [
+                {
+                    "key": "d1d87",
+                    "text": "Hello, world!",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                }
+            ],
+        }
+        result = draftjs_renderer(json.dumps(content))
+        self.assertEqual("<p>Hello, world!</p>", result)
+
+    def test_draftjs_renderer_invalid_json(self):
+        """draftjs_renderer should return an error message if
+        the input is not valid JSON"""
+
+        # Test invalid input
+        content = "not valid JSON"
+
+        with self.assertLogs() as log:
+            self.assertEqual(draftjs_renderer(content), "")
+
+        self.assertIn("Unable to render content", log.output[0])
+
+    def test_draftjs_renderer_inline_tex(self):
+        """draftjs_renderer should render inline tex"""
+
+        tex = r"\frac{1}{2}"
+        inline_latex = {
+            "blocks": [
+                {
+                    "key": "92d7d",
+                    "text": "   ",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 1, "length": 1, "key": 0}],
+                    "data": {},
+                }
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "INLINETEX",
+                    "mutability": "IMMUTABLE",
+                    "data": {"tex": tex, "type": "INLINETEX"},
+                }
+            },
+        }
+        expected_html = f'<p> <span class="ashley-latex-inline">{tex}</span> </p>'
+
+        self.assertEqual(
+            draftjs_renderer(json.dumps(inline_latex)),
+            expected_html,
+        )
+
+    def test_draftjs_renderer_block_tex(self):
+        """draftjs_renderer should render block TEXBLOCK"""
+        tex = r"\frac{1}{2}"
+        block_latex = {
+            "blocks": [
+                {
+                    "key": "3f2dm",
+                    "text": "",
+                    "type": "atomic",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"tex": tex, "type": "TEXBLOCK"},
+                },
+            ]
+        }
+
+        expected_html = f'<span class="ashley-latex-display">{tex}</span>'
+        self.assertEqual(
+            draftjs_renderer(json.dumps(block_latex)),
+            expected_html,
+        )
+
+    def test_draftjs_renderer_atomic_mixing_render_children(self):
+        """
+        Check draftjs_renderer is able to render different type of atomic blocks image and tex,
+        as well as inline tex and simple text
+        """
+        tex = r"\frac{1}{2}"
+        image = "http://localhost:8090/media/image_uploads/1/1/b993e1c036f4.png"
+        draftjs_json = {
+            "blocks": [
+                {
+                    "key": "4771m",
+                    "text": "Hello  ",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [{"offset": 0, "length": 5, "style": "BOLD"}],
+                    "entityRanges": [{"offset": 6, "length": 1, "key": 0}],
+                    "data": {},
+                },
+                {
+                    "key": "597gj",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "bk58g",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "d55a2",
+                    "text": " ",
+                    "type": "atomic",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 0, "length": 1, "key": 1}],
+                    "data": {},
+                },
+                {
+                    "key": "erbih",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "2g4cm",
+                    "text": "",
+                    "type": "atomic",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"tex": tex, "type": "TEXBLOCK"},
+                },
+                {
+                    "key": "egqml",
+                    "text": " ",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "INLINETEX",
+                    "mutability": "IMMUTABLE",
+                    "data": {"tex": tex, "type": "INLINETEX"},
+                },
+                "1": {
+                    "type": "IMAGE",
+                    "mutability": "IMMUTABLE",
+                    "data": {
+                        "src": image,
+                        "width": 4,
+                        "height": 100,
+                        "alignment": "center",
+                    },
+                },
+            },
+        }
+
+        expected_output = (
+            f'<p><strong>Hello</strong> <span class="ashley-latex-inline">{tex}</span></p><p></p>'
+            f'<p></p><img class="image-center" src="{image}" width="4%" height="100%"/>'
+            f'<p></p><span class="ashley-latex-display">{tex}</span><p> </p>'
+        )
+        self.assertEqual(
+            draftjs_renderer(json.dumps(draftjs_json)),
+            expected_output,
+        )


### PR DESCRIPTION
## Purpose

For atomic blocks, we needed a specific behavior for the ones
dealing with the latex formulas. This introduced a problem with
rendering the images. This commit fixes this. To prevent this
kind of error in the future, tests have been added rendering the HTML
using draftjs_exporter. So far only specific decorators were tested
but not all the rendering of multiple draftjs blocks.

## Proposal

call the draft-js exporter render_children method
