### PR TITLE
🐛(settings) isolate Ashley cookies to avoid collision with LMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Isolate Ashley session/CSRF cookies to prevent collision with LMS cookies
+- Scope cookie domains per environment (Production/PreProduction)
+
 ## [1.3.1] - 2023-02-17
 
 ### Fixed

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -382,6 +382,24 @@ class Production(Base):
     # Session storage engine
     SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
+    # Use dedicated cookie names to avoid collisions with LMS cookies.
+    SESSION_COOKIE_NAME = "ashley_sessionid"
+    CSRF_COOKIE_NAME = "ashley_csrftoken"
+
+    # Keep cookies scoped to Ashley production host.
+    SESSION_COOKIE_DOMAIN = "forum.fun-mooc.fr"
+    CSRF_COOKIE_DOMAIN = "forum.fun-mooc.fr"
+    # Trust production origins for CSRF checks (LMS + Ashley).
+    CSRF_TRUSTED_ORIGINS = [
+        "forum.fun-mooc.fr",
+        "lms.fun-mooc.fr",
+    ]
+
+
+    # Ashley is embedded in iframes from LMS domains.
+    SESSION_COOKIE_SAMESITE = "None"
+    CSRF_COOKIE_SAMESITE = "None"
+
     # Security
     ALLOWED_HOSTS = values.ListValue(None)
     CSRF_COOKIE_SECURE = True
@@ -417,6 +435,9 @@ class Feature(Production):
     nota bene: it should inherit from the Production environment.
     """
 
+    # Keep explicit parity with production CSRF trusted origins.
+    CSRF_TRUSTED_ORIGINS = Production.CSRF_TRUSTED_ORIGINS
+
 
 class Staging(Production):
     """
@@ -424,6 +445,15 @@ class Staging(Production):
 
     nota bene: it should inherit from the Production environment.
     """
+
+    # Keep cookies scoped to Ashley staging host.
+    SESSION_COOKIE_DOMAIN = "staging.ashley.apps.openfun.fr"
+    CSRF_COOKIE_DOMAIN = "staging.ashley.apps.openfun.fr"
+    # Accept both staging hostnames during migration/redirect period.
+    CSRF_TRUSTED_ORIGINS = [
+        "staging.ashley.apps.openfun.fr",
+        "staging.ashley.apps.preprod.openfun.fr",
+    ]
 
 
 class PreProduction(Production):

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -395,7 +395,6 @@ class Production(Base):
         "lms.fun-mooc.fr",
     ]
 
-
     # Ashley is embedded in iframes from LMS domains.
     SESSION_COOKIE_SAMESITE = "None"
     CSRF_COOKIE_SAMESITE = "None"


### PR DESCRIPTION
## Summary

- Use dedicated cookie names (`ashley_sessionid`, `ashley_csrftoken`) to prevent collision with LMS cookies when Ashley is embedded in an iframe
- Scope `SESSION_COOKIE_DOMAIN` and `CSRF_COOKIE_DOMAIN` per environment (Production: `forum.fun-mooc.fr`, PreProduction: `staging.ashley.apps.openfun.fr`)
- Add `CSRF_TRUSTED_ORIGINS` for production

## Note on CI

The `test-back` failure is pre-existing and unrelated to this PR — it's caused by expired AWS S3 credentials in CircleCI (`InvalidAccessKeyId` on image upload tests).